### PR TITLE
Fix logical config value content types

### DIFF
--- a/cli/src/Nona.Cli/Entries/ConfigEntryValueRenderer.cs
+++ b/cli/src/Nona.Cli/Entries/ConfigEntryValueRenderer.cs
@@ -1,0 +1,80 @@
+using System.Text.Json;
+
+namespace Nona.Cli.Entries;
+
+internal static class ConfigEntryValueRenderer
+{
+    internal const string LogicalContentTypeHeader = "X-Nona-Content-Type";
+
+    private static readonly JsonSerializerOptions PrettyJsonOptions = new()
+    {
+        WriteIndented = true
+    };
+
+    internal static string NormalizeContentType(string? contentType)
+    {
+        if (string.IsNullOrWhiteSpace(contentType))
+            return "unknown";
+
+        return contentType.Trim().ToLowerInvariant() switch
+        {
+            "json" or "application/json" or "text/json" => "json",
+            "text" or "string" or "plain" or "text/plain" => "text",
+            "number" or "integer" or "float" or "double" or "decimal" => "number",
+            "boolean" or "bool" => "boolean",
+            _ => "unknown"
+        };
+    }
+
+    internal static void WriteValue(string value, string? contentType)
+    {
+        var normalizedContentType = NormalizeContentType(contentType);
+        var output = normalizedContentType switch
+        {
+            "json" => TryFormatJson(value, out var formattedJson) ? formattedJson : value,
+            "number" => IsJsonKind(value, JsonValueKind.Number) ? value.Trim() : value,
+            "boolean" => IsJsonKind(value, JsonValueKind.True, JsonValueKind.False) ? value.Trim().ToLowerInvariant() : value,
+            "text" => value,
+            _ => TryFormatJson(value, out var formattedFallback) ? formattedFallback : value
+        };
+
+        Console.WriteLine(output);
+    }
+
+    private static bool TryFormatJson(string value, out string formatted)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(value);
+            formatted = JsonSerializer.Serialize(document.RootElement, PrettyJsonOptions);
+            return true;
+        }
+        catch (JsonException)
+        {
+            formatted = string.Empty;
+            return false;
+        }
+        catch (ArgumentException)
+        {
+            formatted = string.Empty;
+            return false;
+        }
+    }
+
+    private static bool IsJsonKind(string value, params JsonValueKind[] expectedKinds)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(value);
+            return expectedKinds.Contains(document.RootElement.ValueKind);
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+    }
+}

--- a/cli/src/Nona.Cli/Entries/EntriesCommands.cs
+++ b/cli/src/Nona.Cli/Entries/EntriesCommands.cs
@@ -81,7 +81,7 @@ internal sealed class EntriesCommands(CliContext ctx) : ICliCommandGroup
     {
         var valueOpt = new Option<string?>("--value", "The config value.");
         var scopeOpt = new Option<string?>("--scope", "Scope: client, server, or all.");
-        var contentTypeOpt = new Option<string?>("--content-type", "MIME content type.");
+        var contentTypeOpt = new Option<string?>("--content-type", "Logical content type: json, text, number, or boolean.");
 
         scopeOpt.AddValidator(result =>
         {

--- a/cli/src/Nona.Cli/Entries/Queries/GetEntryQuery.cs
+++ b/cli/src/Nona.Cli/Entries/Queries/GetEntryQuery.cs
@@ -1,5 +1,7 @@
 using Microsoft.Kiota.Abstractions;
+using Nona.Cli.Entries;
 using Nona.Cli.Generated.Models;
+using System.Net;
 
 namespace Nona.Cli.Entries.Queries;
 
@@ -11,7 +13,45 @@ internal sealed class GetEntryQueryHandler(Func<HttpClient>? httpClientFactory =
 
     public async Task<int> HandleAsync(GetEntryQuery query, CancellationToken ct)
     {
+        if (IsLikelyApiKey(query.Connection.BearerToken))
+            return await GetRawEntryAsync(query, ct);
 
+        return await GetAdminEntryAsync(query, ct);
+    }
+
+    private async Task<int> GetRawEntryAsync(GetEntryQuery query, CancellationToken ct)
+    {
+        using var http = httpClientFactory?.Invoke() ?? new HttpClient();
+        using var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            BuildRawEntryUrl(query.Connection.BaseUrl, query.Environment, query.Key));
+
+        request.Headers.TryAddWithoutValidation("X-Api-Key", query.Connection.BearerToken);
+        request.Headers.TryAddWithoutValidation("Accept", "application/json");
+
+        using var response = await http.SendAsync(request, ct);
+        if (response.StatusCode == HttpStatusCode.NotFound)
+        {
+            Console.Error.WriteLine($"Entry '{query.Key}' not found in [{query.Environment}].");
+            return 1;
+        }
+
+        if (response.StatusCode == HttpStatusCode.Unauthorized)
+        {
+            Console.Error.WriteLine("API key is missing or invalid.");
+            return 1;
+        }
+
+        response.EnsureSuccessStatusCode();
+
+        var value = await response.Content.ReadAsStringAsync(ct);
+        var contentType = ReadLogicalContentType(response);
+        ConfigEntryValueRenderer.WriteValue(value, contentType);
+        return 0;
+    }
+
+    private async Task<int> GetAdminEntryAsync(GetEntryQuery query, CancellationToken ct)
+    {
         var api = NonaClientFactory.Create(query.Connection, httpClientFactory);
 
         ConfigEntryDto? entry;
@@ -27,7 +67,18 @@ internal sealed class GetEntryQueryHandler(Func<HttpClient>? httpClientFactory =
             return 1;
         }
 
-        ListEntriesQueryHandler.WriteEntry(entry!);
+        ConfigEntryValueRenderer.WriteValue(entry!.Value ?? string.Empty, entry.ContentType);
         return 0;
     }
+
+    private static bool IsLikelyApiKey(string? token)
+        => token is { Length: 64 } && token.All(Uri.IsHexDigit);
+
+    private static string BuildRawEntryUrl(string baseUrl, string environment, string key)
+        => $"{baseUrl.TrimEnd('/')}/api/{Uri.EscapeDataString(environment)}/{Uri.EscapeDataString(key)}";
+
+    private static string? ReadLogicalContentType(HttpResponseMessage response)
+        => response.Headers.TryGetValues(ConfigEntryValueRenderer.LogicalContentTypeHeader, out var values)
+            ? values.FirstOrDefault()
+            : null;
 }

--- a/cli/src/Nona.Cli/Entries/Queries/ListEntriesQuery.cs
+++ b/cli/src/Nona.Cli/Entries/Queries/ListEntriesQuery.cs
@@ -1,4 +1,5 @@
 using Nona.Cli.Generated.Models;
+using Nona.Cli.Entries;
 
 namespace Nona.Cli.Entries.Queries;
 
@@ -33,7 +34,7 @@ internal sealed class ListEntriesQueryHandler(Func<HttpClient>? httpClientFactor
         Console.WriteLine($"  {entry.Key}");
         Console.WriteLine($"    Value:        {entry.Value}");
         Console.WriteLine($"    Scope:        {entry.Scope}");
-        Console.WriteLine($"    Content-Type: {entry.ContentType}");
+        Console.WriteLine($"    Content-Type: {ConfigEntryValueRenderer.NormalizeContentType(entry.ContentType)}");
         Console.WriteLine($"    Updated:      {entry.UpdatedAt:O}");
     }
 }

--- a/cli/tests/Nona.Cli.Tests/Entries/EntriesHandlerTests.cs
+++ b/cli/tests/Nona.Cli.Tests/Entries/EntriesHandlerTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using Nona.Cli.Entries;
 using Nona.Cli.Entries.Commands;
 using Nona.Cli.Entries.Queries;
 using static Nona.Cli.Tests.Fixtures;
@@ -9,6 +10,7 @@ namespace Nona.Cli.Tests.Entries;
 public sealed class EntriesHandlerTests
 {
     private static readonly NonaCliConnectionOptions TestConnection = new("http://nona.test", "test-token");
+    private static readonly NonaCliConnectionOptions ApiKeyConnection = new("http://nona.test", new string('A', 64));
 
     [Test]
     public async Task ListEntriesQueryHandler_ReturnsZero_WithEntries()
@@ -31,6 +33,17 @@ public sealed class EntriesHandlerTests
     {
         var result = await new GetEntryQueryHandler(MockHttp(HttpStatusCode.OK, ConfigEntryJson))
             .HandleAsync(new GetEntryQuery(TestConnection, "my-project", "production", "my.key"), CancellationToken.None);
+        await Assert.That(result).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task GetEntryQueryHandler_ReturnsZero_WhenRawValueFound()
+    {
+        var result = await new GetEntryQueryHandler(MockHttp(
+                HttpStatusCode.OK,
+                """{"enabled":true}""",
+                new Dictionary<string, string> { [ConfigEntryValueRenderer.LogicalContentTypeHeader] = "json" }))
+            .HandleAsync(new GetEntryQuery(ApiKeyConnection, "my-project", "production", "my.key"), CancellationToken.None);
         await Assert.That(result).IsEqualTo(0);
     }
 

--- a/cli/tests/Nona.Cli.Tests/TestHelpers.cs
+++ b/cli/tests/Nona.Cli.Tests/TestHelpers.cs
@@ -6,7 +6,10 @@ namespace Nona.Cli.Tests;
 internal static class TestHelpers
 {
     internal static Func<HttpClient> MockHttp(HttpStatusCode status, string json)
-        => () => new HttpClient(new StaticMockHandler(status, json));
+        => () => new HttpClient(new StaticMockHandler(status, json, null));
+
+    internal static Func<HttpClient> MockHttp(HttpStatusCode status, string json, IReadOnlyDictionary<string, string> headers)
+        => () => new HttpClient(new StaticMockHandler(status, json, headers));
 
     internal sealed class TempFile : IDisposable
     {
@@ -34,13 +37,23 @@ internal static class TestHelpers
         }
     }
 
-    private sealed class StaticMockHandler(HttpStatusCode status, string body) : HttpMessageHandler
+    private sealed class StaticMockHandler(HttpStatusCode status, string body, IReadOnlyDictionary<string, string>? headers) : HttpMessageHandler
     {
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
-            => Task.FromResult(new HttpResponseMessage(status)
+        {
+            var response = new HttpResponseMessage(status)
             {
                 Content = new StringContent(body, Encoding.UTF8, "application/json")
-            });
+            };
+
+            if (headers is not null)
+            {
+                foreach (var (name, value) in headers)
+                    response.Headers.TryAddWithoutValidation(name, value);
+            }
+
+            return Task.FromResult(response);
+        }
     }
 }
 
@@ -59,7 +72,7 @@ internal static class Fixtures
     internal const string ApiKeyArrayJson = $"[{ApiKeyJson}]";
 
     internal const string ConfigEntryJson = """
-        {"project":"my-project","environment":"production","key":"my.key","value":"my-value","contentType":"string","scope":"all","createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z"}
+        {"project":"my-project","environment":"production","key":"my.key","value":"my-value","contentType":"text","scope":"all","createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z"}
         """;
 
     internal const string ConfigEntryArrayJson = $"[{ConfigEntryJson}]";

--- a/core/src/Application/Admin/ConfigEntries/Commands/UpsertConfigEntryCommand.cs
+++ b/core/src/Application/Admin/ConfigEntries/Commands/UpsertConfigEntryCommand.cs
@@ -40,15 +40,19 @@ public class UpsertConfigEntryCommandHandler(
         if (scope is null && request.Scope is not null)
             return new UpsertConfigEntryResult(false, null, "Invalid scope. Must be 'client', 'server', or 'all'");
 
-        var now = dateTime.NowUtc;
         var existingEntry = await configEntryRepository.GetAsync(projectName, request.EnvironmentName, request.Key, cancellationToken);
+        var contentType = ResolveContentType(request.ContentType, existingEntry, request.Value, out var contentTypeError);
+        if (contentTypeError is not null)
+            return new UpsertConfigEntryResult(false, null, contentTypeError);
+
+        var now = dateTime.NowUtc;
         var action = existingEntry is null ? "Created Key" : "Updated Key";
 
         ConfigEntry entry;
         if (existingEntry is not null)
         {
             existingEntry.Value = request.Value;
-            existingEntry.ContentType = request.ContentType ?? existingEntry.ContentType;
+            existingEntry.ContentType = contentType;
             existingEntry.Scope = scope ?? existingEntry.Scope;
             existingEntry.UpdatedAt = now;
             await configEntryRepository.UpdateAsync(existingEntry, cancellationToken);
@@ -62,7 +66,7 @@ public class UpsertConfigEntryCommandHandler(
                 Environment = request.EnvironmentName,
                 Key = request.Key,
                 Value = request.Value,
-                ContentType = request.ContentType ?? "string",
+                ContentType = contentType,
                 Scope = scope ?? KeyScope.All,
                 CreatedAt = now,
                 UpdatedAt = now
@@ -105,5 +109,30 @@ public class UpsertConfigEntryCommandHandler(
             "all" => KeyScope.All,
             _ => null
         };
+    }
+
+    private static string ResolveContentType(
+        string? requestedContentType,
+        ConfigEntry? existingEntry,
+        string value,
+        out string? error)
+    {
+        error = null;
+
+        var normalizedRequested = ConfigEntryContentTypes.Normalize(requestedContentType);
+        if (!string.IsNullOrWhiteSpace(requestedContentType) && normalizedRequested is null)
+        {
+            error = $"Content type must be one of: {string.Join(", ", ConfigEntryContentTypes.LogicalTypes)}.";
+            return ConfigEntryContentTypes.Text;
+        }
+
+        var contentType = normalizedRequested
+            ?? ConfigEntryContentTypes.Normalize(existingEntry?.ContentType)
+            ?? ConfigEntryContentTypes.Infer(value);
+
+        if (!ConfigEntryContentTypes.IsValidValue(value, contentType, out var validationError))
+            error = validationError;
+
+        return contentType;
     }
 }

--- a/core/src/Application/Admin/ConfigEntries/Validators/UpsertConfigEntryRequestValidator.cs
+++ b/core/src/Application/Admin/ConfigEntries/Validators/UpsertConfigEntryRequestValidator.cs
@@ -1,4 +1,5 @@
 using Nona.Application.Admin.ConfigEntries.Commands;
+using Nona.Application.Common;
 
 namespace Nona.Application.Admin.ConfigEntries.Validators;
 
@@ -16,5 +17,20 @@ public class UpsertConfigEntryRequestValidator : AbstractValidator<UpsertConfigE
             .Must(scope => scope is null || ValidScopes.Contains(scope.ToLowerInvariant()))
             .When(x => x.Scope is not null)
             .WithMessage("Scope must be 'client', 'server', or 'all'");
+
+        RuleFor(x => x.ContentType)
+            .Must(contentType => string.IsNullOrWhiteSpace(contentType) || ConfigEntryContentTypes.Normalize(contentType) is not null)
+            .WithMessage($"Content type must be one of: {string.Join(", ", ConfigEntryContentTypes.LogicalTypes)}.");
+
+        RuleFor(x => x)
+            .Custom((request, context) =>
+            {
+                var contentType = ConfigEntryContentTypes.Normalize(request.ContentType);
+                if (contentType is null)
+                    return;
+
+                if (!ConfigEntryContentTypes.IsValidValue(request.Value, contentType, out var error))
+                    context.AddFailure(nameof(UpsertConfigEntryRequest.Value), error!);
+            });
     }
 }

--- a/core/src/Application/Api/ConfigEntries/Queries/GetConfigEntryValueQuery.cs
+++ b/core/src/Application/Api/ConfigEntries/Queries/GetConfigEntryValueQuery.cs
@@ -1,4 +1,5 @@
 using MediatR;
+using Nona.Application.Common;
 using Nona.Application.Common.Interfaces;
 using Nona.Domain.Interfaces;
 
@@ -6,7 +7,7 @@ namespace Nona.Application.Api.ConfigEntries.Queries;
 
 public record GetConfigEntryValueQuery(string EnvironmentId, string Key) : IRequest<GetConfigEntryValueResult>;
 
-public record GetConfigEntryValueResult(bool Success, string? Value, string? ContentType, string? Error);
+public record GetConfigEntryValueResult(bool Success, string? Value, string? LogicalContentType, string? Error);
 
 public class GetConfigEntryValueQueryHandler(
     IApiKeyRepository apiKeyRepository,
@@ -43,6 +44,9 @@ public class GetConfigEntryValueQueryHandler(
         if ((apiKeyScope & configEntry.Scope) == 0)
             return new GetConfigEntryValueResult(false, null, null, "Config entry not found");
 
-        return new GetConfigEntryValueResult(true, configEntry.Value, configEntry.ContentType, null);
+        var contentType = ConfigEntryContentTypes.Normalize(configEntry.ContentType)
+            ?? ConfigEntryContentTypes.Infer(configEntry.Value);
+
+        return new GetConfigEntryValueResult(true, configEntry.Value, contentType, null);
     }
 }

--- a/core/src/Application/Common/ConfigEntryContentTypes.cs
+++ b/core/src/Application/Common/ConfigEntryContentTypes.cs
@@ -1,0 +1,97 @@
+using System.Text.Json;
+
+namespace Nona.Application.Common;
+
+public static class ConfigEntryContentTypes
+{
+    public const string Json = "json";
+    public const string Text = "text";
+    public const string Number = "number";
+    public const string Boolean = "boolean";
+
+    public static readonly string[] LogicalTypes = [Json, Text, Number, Boolean];
+
+    public static string Resolve(string? contentType, string value)
+        => Normalize(contentType) ?? Infer(value);
+
+    public static string? Normalize(string? contentType)
+    {
+        if (string.IsNullOrWhiteSpace(contentType))
+            return null;
+
+        return contentType.Trim().ToLowerInvariant() switch
+        {
+            Json or "application/json" or "text/json" => Json,
+            Text or "string" or "plain" or "text/plain" => Text,
+            Number or "integer" or "float" or "double" or "decimal" => Number,
+            Boolean or "bool" => Boolean,
+            _ => null
+        };
+    }
+
+    public static string Infer(string value)
+    {
+        var kind = TryGetJsonValueKind(value);
+
+        return kind switch
+        {
+            JsonValueKind.True or JsonValueKind.False => Boolean,
+            JsonValueKind.Number => Number,
+            JsonValueKind.Object or JsonValueKind.Array or JsonValueKind.Null => Json,
+            _ => Text
+        };
+    }
+
+    public static bool IsValidValue(string value, string contentType, out string? error)
+    {
+        error = null;
+
+        switch (Normalize(contentType))
+        {
+            case Json:
+                if (TryGetJsonValueKind(value) is not null)
+                    return true;
+
+                error = "Value must be valid JSON when contentType is 'json'.";
+                return false;
+
+            case Number:
+                if (TryGetJsonValueKind(value) == JsonValueKind.Number)
+                    return true;
+
+                error = "Value must be a valid JSON number when contentType is 'number'.";
+                return false;
+
+            case Boolean:
+                if (TryGetJsonValueKind(value) is JsonValueKind.True or JsonValueKind.False)
+                    return true;
+
+                error = "Value must be 'true' or 'false' when contentType is 'boolean'.";
+                return false;
+
+            case Text:
+                return true;
+
+            default:
+                error = $"Content type must be one of: {string.Join(", ", LogicalTypes)}.";
+                return false;
+        }
+    }
+
+    private static JsonValueKind? TryGetJsonValueKind(string value)
+    {
+        try
+        {
+            using var document = JsonDocument.Parse(value);
+            return document.RootElement.ValueKind;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+        catch (ArgumentException)
+        {
+            return null;
+        }
+    }
+}

--- a/core/src/Domain/Entities/ConfigEntry.cs
+++ b/core/src/Domain/Entities/ConfigEntry.cs
@@ -10,7 +10,7 @@ public class ConfigEntry
 
 
     public required string Value { get; set; }
-    public string ContentType { get; set; } = "string";
+    public string ContentType { get; set; } = "text";
 
     public KeyScope Scope { get; set; } = KeyScope.All;
 

--- a/core/src/Infrastructure/Migrations/001_CreateConfigEntries.sql
+++ b/core/src/Infrastructure/Migrations/001_CreateConfigEntries.sql
@@ -3,7 +3,7 @@ CREATE TABLE IF NOT EXISTS ConfigEntries (
     Environment TEXT NOT NULL COLLATE NOCASE,
     Key TEXT NOT NULL COLLATE NOCASE,
     Value TEXT NOT NULL,
-    ContentType TEXT NOT NULL DEFAULT 'string',
+    ContentType TEXT NOT NULL DEFAULT 'text',
     Scope INTEGER NOT NULL DEFAULT 3,
     CreatedAt TEXT NOT NULL,
     UpdatedAt TEXT NOT NULL,

--- a/core/src/Infrastructure/Migrations/012_NormalizeConfigEntryContentTypes.sql
+++ b/core/src/Infrastructure/Migrations/012_NormalizeConfigEntryContentTypes.sql
@@ -1,0 +1,15 @@
+UPDATE ConfigEntries
+SET ContentType = CASE
+    WHEN lower(trim(ContentType)) IN ('json', 'application/json', 'text/json') THEN 'json'
+    WHEN lower(trim(ContentType)) IN ('number', 'integer', 'float', 'double', 'decimal') THEN 'number'
+    WHEN lower(trim(ContentType)) IN ('boolean', 'bool') THEN 'boolean'
+    WHEN lower(trim(ContentType)) IN ('text', 'plain', 'text/plain', 'string') THEN
+        CASE
+            WHEN json_valid(Value) = 1 AND json_type(Value) IN ('true', 'false') THEN 'boolean'
+            WHEN json_valid(Value) = 1 AND json_type(Value) IN ('integer', 'real') THEN 'number'
+            WHEN json_valid(Value) = 1 AND json_type(Value) IN ('object', 'array', 'null') THEN 'json'
+            ELSE 'text'
+        END
+    ELSE ContentType
+END
+WHERE ContentType IS NOT NULL;

--- a/core/src/WebApi/ConfigValueOpenApiTransformer.cs
+++ b/core/src/WebApi/ConfigValueOpenApiTransformer.cs
@@ -1,0 +1,52 @@
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi;
+using Nona.Application.Common;
+using Nona.WebApi;
+using System.Net.Http;
+
+internal sealed class ConfigValueOpenApiTransformer : IOpenApiDocumentTransformer
+{
+    public Task TransformAsync(OpenApiDocument document, OpenApiDocumentTransformerContext context, CancellationToken cancellationToken)
+    {
+        document.Components?.Schemas?.Remove("ConfigValueResponse");
+
+        if (document.Paths is null
+            || !document.Paths.TryGetValue("/api/{environmentId}/{key}", out var pathItem)
+            || pathItem.Operations is null
+            || !pathItem.Operations.TryGetValue(HttpMethod.Get, out var operation)
+            || operation.Responses is null
+            || !operation.Responses.TryGetValue("200", out var response))
+        {
+            return Task.CompletedTask;
+        }
+
+        var rawResponse = new OpenApiResponse
+        {
+            Description = response.Description ?? "OK",
+            Headers = new Dictionary<string, IOpenApiHeader>(),
+            Content = new Dictionary<string, OpenApiMediaType>()
+        };
+
+        rawResponse.Headers[NonaResponseHeaders.LogicalContentType] = new OpenApiHeader
+        {
+            Description = "Logical Nona value type such as json, text, number, or boolean.",
+            Schema = new OpenApiSchema
+            {
+                Type = JsonSchemaType.String
+            }
+        };
+
+        rawResponse.Content["application/json"] = new OpenApiMediaType
+        {
+            Schema = new OpenApiSchema
+            {
+                Type = JsonSchemaType.String,
+                Description = $"Raw config value. Interpret using the {NonaResponseHeaders.LogicalContentType} response header."
+            }
+        };
+
+        operation.Responses["200"] = rawResponse;
+
+        return Task.CompletedTask;
+    }
+}

--- a/core/src/WebApi/Controllers/Api/ConfigController.cs
+++ b/core/src/WebApi/Controllers/Api/ConfigController.cs
@@ -2,6 +2,8 @@ using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Nona.Application.Api.ConfigEntries.Queries;
+using Nona.Application.Common;
+using Nona.WebApi;
 using Nona.WebApi.Authentication;
 
 namespace Nona.WebApi.Controllers.Api;
@@ -13,7 +15,8 @@ namespace Nona.WebApi.Controllers.Api;
 public class ConfigController(IMediator mediator) : ControllerBase
 {
     [HttpGet("{key}")]
-    [ProducesResponseType(typeof(string), StatusCodes.Status200OK, "text/plain")]
+    [Produces("application/json")]
+    [ProducesResponseType(typeof(string), StatusCodes.Status200OK, "application/json")]
     [ProducesResponseType(StatusCodes.Status401Unauthorized)]
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public async Task<IActionResult> GetConfigValue(string environmentId, string key, CancellationToken cancellationToken)
@@ -29,7 +32,7 @@ public class ConfigController(IMediator mediator) : ControllerBase
             };
         }
 
-        Response.Headers["ContentType"] = result.ContentType!;
-        return Content(result.Value!, "text/plain; charset=utf-8");
+        Response.Headers[NonaResponseHeaders.LogicalContentType] = result.LogicalContentType ?? ConfigEntryContentTypes.Text;
+        return Content(result.Value!, "application/json");
     }
 }

--- a/core/src/WebApi/NonaResponseHeaders.cs
+++ b/core/src/WebApi/NonaResponseHeaders.cs
@@ -1,0 +1,6 @@
+namespace Nona.WebApi;
+
+public static class NonaResponseHeaders
+{
+    public const string LogicalContentType = "X-Nona-Content-Type";
+}

--- a/core/src/WebApi/Program.cs
+++ b/core/src/WebApi/Program.cs
@@ -33,7 +33,7 @@ public partial class Program
                 .SetIsOriginAllowed(_ => true)
                 .AllowAnyHeader()
                 .AllowAnyMethod()
-                .WithExposedHeaders("ContentType")
+                .WithExposedHeaders(NonaResponseHeaders.LogicalContentType)
                 .AllowCredentials());
         });
 
@@ -46,6 +46,7 @@ public partial class Program
                 return Task.CompletedTask;
             });
             o.AddDocumentTransformer<BearerSecuritySchemeTransformer>();
+            o.AddDocumentTransformer<ConfigValueOpenApiTransformer>();
         }
         );
 

--- a/core/tests/Application.Tests/Api/GetConfigEntryValueQueryTests.cs
+++ b/core/tests/Application.Tests/Api/GetConfigEntryValueQueryTests.cs
@@ -330,7 +330,7 @@ public class GetConfigEntryValueQueryTests
 
         // Assert
         await Assert.That(result.Success).IsTrue();
-        await Assert.That(result.ContentType).IsEqualTo("application/json");
+        await Assert.That(result.LogicalContentType).IsEqualTo("json");
     }
 
     #endregion
@@ -415,7 +415,7 @@ public class GetConfigEntryValueQueryTests
                 Environment = EnvironmentName,
                 Key = ConfigKey,
                 Value = ConfigValue,
-                ContentType = "string",
+                ContentType = "text",
                 Scope = scope
             });
     }

--- a/core/tests/Application.Tests/ConfigEntries/UpsertConfigEntryCommandTests.cs
+++ b/core/tests/Application.Tests/ConfigEntries/UpsertConfigEntryCommandTests.cs
@@ -36,6 +36,7 @@ public class UpsertConfigEntryCommandTests
         await Assert.That(result.ConfigEntry).IsNotNull();
         await Assert.That(result.ConfigEntry!.Key).IsEqualTo(ConfigKey);
         await Assert.That(result.ConfigEntry!.Value).IsEqualTo(ConfigValue);
+        await Assert.That(result.ConfigEntry!.ContentType).IsEqualTo("text");
     }
 
     [Test]
@@ -165,5 +166,51 @@ public class UpsertConfigEntryCommandTests
         // Assert
         await Assert.That(result.Success).IsFalse();
         await Assert.That(result.Error).IsEqualTo("Environment not found");
+    }
+
+    [Test]
+    public async Task UpsertConfigEntry_InfersContentType_WhenNotDeclared()
+    {
+        var fixture = new TestFixture();
+        fixture.SetupAsSystemAdmin();
+        fixture.SetupProjectExists(ProjectName);
+        fixture.SetupEnvironmentExists(ProjectName, EnvironmentName);
+
+        var handler = new UpsertConfigEntryCommandHandler(
+            fixture.ProjectRepository,
+            fixture.EnvironmentRepository,
+            fixture.ConfigEntryRepository,
+            fixture.ProjectAccessService,
+            fixture.DateTime);
+
+        var command = new UpsertConfigEntryCommand(ProjectName, EnvironmentName, "max_items", "42", null, null);
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        await Assert.That(result.Success).IsTrue();
+        await Assert.That(result.ConfigEntry!.ContentType).IsEqualTo("number");
+    }
+
+    [Test]
+    public async Task UpsertConfigEntry_RejectsInvalidDeclaredContentTypeValue()
+    {
+        var fixture = new TestFixture();
+        fixture.SetupAsSystemAdmin();
+        fixture.SetupProjectExists(ProjectName);
+        fixture.SetupEnvironmentExists(ProjectName, EnvironmentName);
+
+        var handler = new UpsertConfigEntryCommandHandler(
+            fixture.ProjectRepository,
+            fixture.EnvironmentRepository,
+            fixture.ConfigEntryRepository,
+            fixture.ProjectAccessService,
+            fixture.DateTime);
+
+        var command = new UpsertConfigEntryCommand(ProjectName, EnvironmentName, ConfigKey, "{bad", "json", null);
+
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        await Assert.That(result.Success).IsFalse();
+        await Assert.That(result.Error).IsEqualTo("Value must be valid JSON when contentType is 'json'.");
     }
 }

--- a/core/tests/Application.Tests/ConfigEntries/UpsertConfigEntryRequestValidatorTests.cs
+++ b/core/tests/Application.Tests/ConfigEntries/UpsertConfigEntryRequestValidatorTests.cs
@@ -1,0 +1,43 @@
+using Nona.Application.Admin.ConfigEntries.Commands;
+using Nona.Application.Admin.ConfigEntries.Validators;
+
+namespace Nona.Application.Tests.ConfigEntries;
+
+public class UpsertConfigEntryRequestValidatorTests
+{
+    private readonly UpsertConfigEntryRequestValidator _validator = new();
+
+    [Test]
+    public async Task AllowsValidLogicalContentTypes()
+    {
+        var json = await _validator.ValidateAsync(new UpsertConfigEntryRequest("""{"enabled":true}""", "json", "all"));
+        var number = await _validator.ValidateAsync(new UpsertConfigEntryRequest("42", "number", "all"));
+        var boolean = await _validator.ValidateAsync(new UpsertConfigEntryRequest("true", "boolean", "all"));
+        var text = await _validator.ValidateAsync(new UpsertConfigEntryRequest("hello", "text", "all"));
+
+        await Assert.That(json.IsValid).IsTrue();
+        await Assert.That(number.IsValid).IsTrue();
+        await Assert.That(boolean.IsValid).IsTrue();
+        await Assert.That(text.IsValid).IsTrue();
+    }
+
+    [Test]
+    public async Task RejectsValuesThatDoNotMatchDeclaredContentType()
+    {
+        var json = await _validator.ValidateAsync(new UpsertConfigEntryRequest("{invalid", "json", "all"));
+        var number = await _validator.ValidateAsync(new UpsertConfigEntryRequest("abc", "number", "all"));
+        var boolean = await _validator.ValidateAsync(new UpsertConfigEntryRequest("yes", "boolean", "all"));
+
+        await Assert.That(json.IsValid).IsFalse();
+        await Assert.That(number.IsValid).IsFalse();
+        await Assert.That(boolean.IsValid).IsFalse();
+    }
+
+    [Test]
+    public async Task RejectsUnknownContentType()
+    {
+        var result = await _validator.ValidateAsync(new UpsertConfigEntryRequest("hello", "xml", "all"));
+
+        await Assert.That(result.IsValid).IsFalse();
+    }
+}

--- a/core/tests/Infrastructure.Tests/ConfigApiControllerTests.cs
+++ b/core/tests/Infrastructure.Tests/ConfigApiControllerTests.cs
@@ -2,6 +2,7 @@ using MediatR;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Nona.Application.Api.ConfigEntries.Queries;
+using Nona.WebApi;
 using Nona.WebApi.Controllers.Api;
 
 namespace Nona.Infrastructure.Tests;
@@ -9,7 +10,7 @@ namespace Nona.Infrastructure.Tests;
 public class ConfigApiControllerTests
 {
     [Test]
-    public async Task GetConfigValue_ReturnsValueBodyAndContentTypeHeader()
+    public async Task GetConfigValue_ReturnsRawValueBodyAndLogicalContentTypeHeader()
     {
         var mediator = new StubMediator(new GetConfigEntryValueResult(true, """{"enabled":true}""", "json", null));
         var controller = new ConfigController(mediator)
@@ -25,8 +26,8 @@ public class ConfigApiControllerTests
         var content = result as ContentResult;
         await Assert.That(content).IsNotNull();
         await Assert.That(content!.Content).IsEqualTo("""{"enabled":true}""");
-        await Assert.That(content.ContentType).IsEqualTo("text/plain; charset=utf-8");
-        await Assert.That(controller.Response.Headers["ContentType"].ToString()).IsEqualTo("json");
+        await Assert.That(content.ContentType).IsEqualTo("application/json");
+        await Assert.That(controller.Response.Headers[NonaResponseHeaders.LogicalContentType].ToString()).IsEqualTo("json");
     }
 
     private sealed class StubMediator(GetConfigEntryValueResult result) : IMediator

--- a/core/tests/StorageBenchmarks/DatabaseSeeder.cs
+++ b/core/tests/StorageBenchmarks/DatabaseSeeder.cs
@@ -161,7 +161,7 @@ internal static class DatabaseSeeder
                     Environment = environment,
                     Key = BuildKey(index),
                     Value = BuildValue(dataset, index),
-                    ContentType = "string",
+                    ContentType = "text",
                     Scope = 3,
                     CreatedAt = now,
                     UpdatedAt = now

--- a/migrator/src/FirebaseRemoteConfigMigrator/Service/MigrationPlanner.cs
+++ b/migrator/src/FirebaseRemoteConfigMigrator/Service/MigrationPlanner.cs
@@ -67,15 +67,15 @@ internal static class MigrationPlanner
         ICollection<string> warnings)
     {
         if (string.IsNullOrWhiteSpace(firebaseValueType))
-            return "string";
+            return "text";
 
         return firebaseValueType.Trim().ToUpperInvariant() switch
         {
-            "STRING" => "string",
+            "STRING" => "text",
             "BOOLEAN" => "boolean",
             "NUMBER" => "number",
             "JSON" => "json",
-            "PARAMETER_VALUE_TYPE_UNSPECIFIED" => "string",
+            "PARAMETER_VALUE_TYPE_UNSPECIFIED" => "text",
             _ => WarnAndUseFallback(key, firebaseValueType, warnings)
         };
     }
@@ -87,8 +87,8 @@ internal static class MigrationPlanner
     {
         warnings.Add(
             $"Unknown Firebase valueType '{firebaseValueType}' for key '{key}'. " +
-            "Using fallback content type 'string'.");
-        return "string";
+            "Using fallback content type 'text'.");
+        return "text";
     }
 
     private static bool ShouldApplyDefault(string environment, MigrationOptions options)

--- a/migrator/tests/FirebaseRemoteConfigMigrator.Tests/MigrationPlannerTests.cs
+++ b/migrator/tests/FirebaseRemoteConfigMigrator.Tests/MigrationPlannerTests.cs
@@ -88,7 +88,7 @@ public class MigrationPlannerTests
         await Assert.That(plan.Entries).Count().IsEqualTo(2);
         await Assert.That(plan.Entries.Single(entry => entry.Environment == "dev").Value).IsEqualTo("https://dev.example.com");
         await Assert.That(plan.Entries.Single(entry => entry.Environment == "prod").Value).IsEqualTo("https://prod.example.com");
-        await Assert.That(plan.Entries.Select(static entry => entry.ContentType).Distinct()).IsEquivalentTo(["string"]);
+        await Assert.That(plan.Entries.Select(static entry => entry.ContentType).Distinct()).IsEquivalentTo(["text"]);
         await Assert.That(plan.Entries.Select(static entry => entry.Scope).Distinct()).IsEquivalentTo(["client"]);
     }
 
@@ -196,12 +196,12 @@ public class MigrationPlannerTests
         [
             new MigrationPlan(
                 ["prod"],
-                [new PlannedConfigEntry("prod", "shared_key", "42", "string", "client", "Client/defaultValue")],
+                [new PlannedConfigEntry("prod", "shared_key", "42", "text", "client", "Client/defaultValue")],
                 [],
                 1),
             new MigrationPlan(
                 ["prod"],
-                [new PlannedConfigEntry("prod", "shared_key", "77", "string", "server", "Server/defaultValue")],
+                [new PlannedConfigEntry("prod", "shared_key", "77", "text", "server", "Server/defaultValue")],
                 [],
                 1)
         ]);
@@ -224,7 +224,7 @@ public class MigrationPlannerTests
                 1),
             new MigrationPlan(
                 ["prod"],
-                [new PlannedConfigEntry("prod", "shared_key", "42", "string", "server", "Server/defaultValue")],
+                [new PlannedConfigEntry("prod", "shared_key", "42", "text", "server", "Server/defaultValue")],
                 [],
                 1)
         ]);
@@ -242,12 +242,12 @@ public class MigrationPlannerTests
         [
             new MigrationPlan(
                 ["prod"],
-                [new PlannedConfigEntry("prod", "shared_key", "42", "string", "client", "Client/defaultValue")],
+                [new PlannedConfigEntry("prod", "shared_key", "42", "text", "client", "Client/defaultValue")],
                 [],
                 1),
             new MigrationPlan(
                 ["prod"],
-                [new PlannedConfigEntry("prod", "shared_key", "77", "string", "server", "Server/defaultValue")],
+                [new PlannedConfigEntry("prod", "shared_key", "77", "text", "server", "Server/defaultValue")],
                 [],
                 1)
         ],
@@ -268,16 +268,16 @@ public class MigrationPlannerTests
             new MigrationPlan(
                 ["dev", "prod"],
                 [
-                    new PlannedConfigEntry("dev", "shared_key", "42", "string", "client", "Client/defaultValue"),
-                    new PlannedConfigEntry("prod", "shared_key", "42", "string", "client", "Client/defaultValue")
+                    new PlannedConfigEntry("dev", "shared_key", "42", "text", "client", "Client/defaultValue"),
+                    new PlannedConfigEntry("prod", "shared_key", "42", "text", "client", "Client/defaultValue")
                 ],
                 [],
                 1),
             new MigrationPlan(
                 ["dev", "prod"],
                 [
-                    new PlannedConfigEntry("dev", "shared_key", "77", "string", "server", "Server/defaultValue"),
-                    new PlannedConfigEntry("prod", "shared_key", "88", "string", "server", "Server/defaultValue")
+                    new PlannedConfigEntry("dev", "shared_key", "77", "text", "server", "Server/defaultValue"),
+                    new PlannedConfigEntry("prod", "shared_key", "88", "text", "server", "Server/defaultValue")
                 ],
                 [],
                 1)


### PR DESCRIPTION
## Summary
- Return raw config values with `Content-Type: application/json` and `X-Nona-Content-Type` logical type metadata.
- Normalize, infer, validate, and migrate config entry content types from legacy `string` to `text`/`json`/`number`/`boolean`.
- Update CLI read/list rendering and Firebase migrator output for logical content types.

## Verification
- `dotnet build NonaConfig.slnx`
- `dotnet test core/tests/Application.Tests/Application.Tests.csproj --no-restore`
- `dotnet test core/tests/Infrastructure.Tests/Infrastructure.Tests.csproj --no-restore`
- `dotnet test cli/tests/Nona.Cli.Tests/Nona.Cli.Tests.csproj --no-restore`
- `dotnet test migrator/tests/FirebaseRemoteConfigMigrator.Tests/Migrator.FirebaseRemoteConfig.Tests.csproj --no-restore`