### PR TITLE
Release UI Remodel

### DIFF
--- a/admin/README.md
+++ b/admin/README.md
@@ -12,6 +12,18 @@ npm install
 npm run dev
 ```
 
+## Verify
+
+Run from `nona-config/admin`:
+
+```bash
+npx tsc -b
+npx vitest run
+npx eslint src --max-warnings 0
+```
+
+`eslint` is currently clean apart from the known `boundaries` deprecation warning emitted by the plugin itself.
+
 ## Configuration
 
 Development uses same-origin API URLs and proxies backend routes through Vite:
@@ -31,3 +43,15 @@ origins.
 - Vite
 - Tailwind CSS
 - TanStack Query
+
+## Key Admin Flows
+
+### Project sub-pages
+
+- Project detail pages do not use a shared project title/description header anymore.
+- Each sub-page owns its own section header and actions:
+  - Parameters: search, bulk import, add parameter
+  - Environments: add environment
+  - API Keys: add API key
+  - Releases / Shared Links: page-specific actions in the section header
+

--- a/admin/src/__tests__/integration/ProjectPage.test.tsx
+++ b/admin/src/__tests__/integration/ProjectPage.test.tsx
@@ -269,7 +269,7 @@ describe('ProjectPage', () => {
     expect(await screen.findByText('API_URL')).toBeInTheDocument();
   });
 
-  it('publishes a configuration release', async () => {
+  it('publishes a configuration release without auto-activating when a release is already active', async () => {
     const publishRequests: Array<{ version: string; makeActive: boolean }> = [];
     server.use(
       http.post(
@@ -293,17 +293,22 @@ describe('ProjectPage', () => {
 
     renderProjectPage('/projects/my-app/releases');
 
+    // Guided flow: Create a version -> enter version -> land on the parameters
+    // step -> Create release. Publishing must not auto-activate here.
+    fireEvent.click(await screen.findByTestId('release-create-version-button'));
     fireEvent.input(await screen.findByTestId('release-version-input'), {
-      target: { value: '1.2.0' },
+      target: { value: '1.2' },
     });
-    fireEvent.click(screen.getByTestId('release-publish-button'));
+    fireEvent.click(screen.getByTestId('release-version-confirm-button'));
+
+    fireEvent.click(await screen.findByTestId('release-create-confirm-button'));
 
     await waitFor(() => {
-      expect(publishRequests).toEqual([{ version: '1.2.0', makeActive: true }]);
+      expect(publishRequests).toEqual([{ version: '1.2.0', makeActive: false }]);
     });
   });
 
-  it('keeps the release version when publishing fails', async () => {
+  it('keeps you on the parameters step when creating the release fails', async () => {
     server.use(
       http.post(
         'http://localhost:5027/admin/projects/:projectId/environments/:envName/releases',
@@ -313,12 +318,57 @@ describe('ProjectPage', () => {
 
     renderProjectPage('/projects/my-app/releases');
 
-    const versionInput = await screen.findByTestId('release-version-input');
-    fireEvent.input(versionInput, { target: { value: '1.2.0' } });
-    fireEvent.click(screen.getByTestId('release-publish-button'));
+    fireEvent.click(await screen.findByTestId('release-create-version-button'));
+    fireEvent.input(await screen.findByTestId('release-version-input'), {
+      target: { value: '1.2' },
+    });
+    fireEvent.click(screen.getByTestId('release-version-confirm-button'));
+
+    fireEvent.click(await screen.findByTestId('release-create-confirm-button'));
 
     expect(await screen.findByText('Release already exists')).toBeInTheDocument();
-    expect(versionInput).toHaveValue('1.2.0');
+    // Still on the parameters step so the user can retry.
+    expect(screen.getByTestId('release-create-confirm-button')).toBeInTheDocument();
+  });
+
+  it('amends a release into a new patch version via the guided flow', async () => {
+    const draftRequests: string[] = [];
+    const publishRequests: Array<{ version: string; makeActive: boolean }> = [];
+    server.use(
+      http.post(
+        'http://localhost:5027/admin/projects/:projectId/environments/:envName/releases/:version/draft',
+        ({ params }) => {
+          draftRequests.push(String(params.version));
+          return HttpResponse.json([]);
+        },
+      ),
+      http.post(
+        'http://localhost:5027/admin/projects/:projectId/environments/:envName/releases',
+        async ({ request }) => {
+          publishRequests.push(
+            (await request.json()) as { version: string; makeActive: boolean },
+          );
+          return HttpResponse.json({}, { status: 201 });
+        },
+      ),
+    );
+
+    renderProjectPage('/projects/my-app/releases');
+
+    // Amend the release -> auto next patch and jump straight into compose mode.
+    fireEvent.click(await screen.findByTestId('release-amend-1.1.0'));
+
+    await waitFor(() => {
+      expect(draftRequests).toEqual(['1.1.0']);
+    });
+
+    expect(screen.queryByTestId('release-version-dialog')).not.toBeInTheDocument();
+    expect(await screen.findByTestId('release-create-confirm-button')).toBeInTheDocument();
+
+    fireEvent.click(await screen.findByTestId('release-create-confirm-button'));
+    await waitFor(() => {
+      expect(publishRequests).toEqual([{ version: '1.1.1', makeActive: false }]);
+    });
   });
 
   it('activates a configuration release', async () => {
@@ -347,33 +397,23 @@ describe('ProjectPage', () => {
     const enabledActivate = activateButtons.find(button => !button.hasAttribute('disabled'));
     expect(enabledActivate).toBeTruthy();
     fireEvent.click(enabledActivate!);
+    expect(await screen.findByTestId('release-activate-dialog')).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('release-activate-confirm-button'));
 
     await waitFor(() => {
       expect(activeRequests).toEqual([{ version: '1.1.0' }]);
     });
   });
 
-  it('creates a working draft from a release after confirmation', async () => {
-    const draftRequests: string[] = [];
-    server.use(
-      http.post(
-        'http://localhost:5027/admin/projects/:projectId/environments/:envName/releases/:version/draft',
-        ({ params }) => {
-          draftRequests.push(String(params.version));
-          return HttpResponse.json([]);
-        },
-      ),
-    );
-
+  it('opens release parameters on the parameters page without starting an amend flow', async () => {
     renderProjectPage('/projects/my-app/releases');
 
-    fireEvent.click(await screen.findByTestId('release-draft-1.1.0'));
-    expect(await screen.findByTestId('release-draft-dialog')).toBeInTheDocument();
-    fireEvent.click(screen.getByTestId('release-draft-confirm-button'));
+    fireEvent.click(await screen.findByTestId('release-view-1.1.0'));
 
-    await waitFor(() => {
-      expect(draftRequests).toEqual(['1.1.0']);
-    });
+    expect(await screen.findByTestId('release-view-banner')).toBeInTheDocument();
+    expect(await screen.findByTestId('project-parameters-heading')).toBeInTheDocument();
+    expect(await screen.findByTestId('parameter-row-API_URL')).toBeInTheDocument();
+    expect(screen.queryByTestId('release-create-confirm-button')).not.toBeInTheDocument();
   });
 
   it('deletes a non-active release after confirmation', async () => {

--- a/admin/src/__tests__/mocks/handlers.ts
+++ b/admin/src/__tests__/mocks/handlers.ts
@@ -238,6 +238,35 @@ export const handlers = [
     return HttpResponse.json(releases);
   }),
 
+  http.get(`${BASE}/admin/projects/:projectId/environments/:envName/releases/:version`, ({ params }) => {
+    const release = mockConfigReleases.find(
+      (item) =>
+        item.project === params.projectId &&
+        item.environment === params.envName &&
+        item.version === params.version,
+    );
+
+    if (!release) {
+      return HttpResponse.json({ error: 'Not found' }, { status: 404 });
+    }
+
+    const entries = mockConfigEntries
+      .filter(
+        (entry) => entry.project === params.projectId && entry.environment === params.envName,
+      )
+      .map((entry) => ({
+        key: entry.key,
+        value: entry.value,
+        contentType: entry.contentType,
+        scope: entry.scope,
+      }));
+
+    return HttpResponse.json({
+      ...release,
+      entries,
+    });
+  }),
+
   http.post(`${BASE}/admin/projects/:projectId/environments/:envName/releases`, async ({ params, request }) => {
     const body = await request.json() as { version: string; makeActive?: boolean };
     return HttpResponse.json({

--- a/admin/src/entities/project/api/config-release.service.ts
+++ b/admin/src/entities/project/api/config-release.service.ts
@@ -17,6 +17,16 @@ export const configReleaseService = {
     );
   },
 
+  async get(
+    projectId: string,
+    environmentName: string,
+    version: string,
+  ): Promise<ConfigReleaseDetails> {
+    return apiClient.get<ConfigReleaseDetails>(
+      `/admin/projects/${segment(projectId)}/environments/${segment(environmentName)}/releases/${segment(version)}`,
+    );
+  },
+
   async publish(
     projectId: string,
     environmentName: string,

--- a/admin/src/entities/project/model/active-environment.ts
+++ b/admin/src/entities/project/model/active-environment.ts
@@ -4,11 +4,16 @@ import type { Environment } from "./types";
 
 type ActiveEnvironmentMap = Record<string, string>;
 
-// eslint-disable-next-line solid/reactivity -- persisted signal intentionally lives at module scope.
-const [activeEnvironmentByProjectSignal, setActiveEnvironmentByProjectSignal] =
-  makePersisted(createSignal<ActiveEnvironmentMap>({}), {
+const persistedActiveEnvironmentState =
+  makePersisted(
+    // eslint-disable-next-line solid/reactivity -- persisted signal intentionally lives at module scope.
+    createSignal<ActiveEnvironmentMap>({}),
+    {
     name: "active_environment_by_project",
-  });
+    }
+  );
+const [activeEnvironmentByProjectSignal, setActiveEnvironmentByProjectSignal] =
+  persistedActiveEnvironmentState;
 
 function normalizeProjectSlug(projectSlug: string) {
   return projectSlug.trim();

--- a/admin/src/entities/project/queries/keys.ts
+++ b/admin/src/entities/project/queries/keys.ts
@@ -30,6 +30,10 @@ export const projectKeys = {
   configReleases: (slug: string, env: string) =>
     [...projectKeys.detail(slug), "config-releases", env] as const,
 
+  /** Details for a specific config release version */
+  configReleaseDetails: (slug: string, env: string, version: string) =>
+    [...projectKeys.configReleases(slug, env), version] as const,
+
   /** Version history for a specific config entry */
   configEntryHistory: (slug: string, env: string, key: string) =>
     [...projectKeys.configEntries(slug, env), key, "history"] as const,

--- a/admin/src/features/project-environments/ProjectEnvironments.tsx
+++ b/admin/src/features/project-environments/ProjectEnvironments.tsx
@@ -58,10 +58,12 @@ export function ProjectEnvironments(props: ProjectEnvironmentsProps) {
             data-testid="project-add-environment-button"
             type="button"
             onClick={() => props.setShowEnvForm(!props.showEnvForm)}
-            class="bg-primary text-on-primary inline-flex h-10 cursor-pointer items-center gap-1.5 self-start rounded-lg border-0 px-4 text-[13px] font-semibold transition-all hover:brightness-105 active:scale-[0.98] md:self-auto"
+            aria-label="Add Environment"
+            title="Add Environment"
+            class="bg-primary text-on-primary inline-flex h-10 w-10 cursor-pointer items-center justify-center gap-1.5 self-end rounded-lg border-0 px-0 text-[13px] font-semibold transition-all hover:brightness-105 active:scale-[0.98] md:h-10 md:w-auto md:px-4 md:self-auto"
           >
             <MIcon name="add" class="text-[17px]" />
-            Add Environment
+            <span class="hidden md:inline">Add Environment</span>
           </button>
         </Show>
       </div>
@@ -159,10 +161,12 @@ export function ProjectEnvironments(props: ProjectEnvironmentsProps) {
                     <button
                       type="button"
                       onClick={() => props.setActiveEnvName(env.name)}
-                      class="bg-surface-container-high text-on-surface hover:bg-surface-bright inline-flex h-9 cursor-pointer items-center gap-1.5 rounded-lg border-0 px-3 text-[12px] font-semibold"
+                      aria-label={`Set ${env.name} as active`}
+                      title={`Set ${env.name} as active`}
+                      class="bg-surface-container-high text-on-surface hover:bg-surface-bright inline-flex h-9 w-9 cursor-pointer items-center justify-center gap-1.5 rounded-lg border-0 px-0 text-[12px] font-semibold md:w-auto md:px-3"
                     >
                       <MIcon name="check_circle" class="text-[15px]" />
-                      Set Active
+                      <span class="hidden md:inline">Set Active</span>
                     </button>
                   </Show>
                   <Show when={props.canManage}>
@@ -170,11 +174,12 @@ export function ProjectEnvironments(props: ProjectEnvironmentsProps) {
                       data-testid={`environment-delete-${env.name}`}
                       type="button"
                       onClick={() => props.onDeleteEnv(env.name)}
-                      class="bg-error-container/10 text-error hover:bg-error-container/20 inline-flex h-9 cursor-pointer items-center gap-1.5 rounded-lg border-0 px-3 text-[12px] font-semibold"
+                      aria-label={`Delete environment ${env.name}`}
+                      class="bg-error-container/10 text-error hover:bg-error-container/20 inline-flex h-9 w-9 cursor-pointer items-center justify-center gap-1.5 rounded-lg border-0 px-0 text-[12px] font-semibold md:w-auto md:px-3"
                       title={`Delete environment ${env.name}`}
                     >
                       <MIcon name="delete" class="text-[15px]" />
-                      Delete
+                      <span class="hidden md:inline">Delete</span>
                     </button>
                   </Show>
                 </div>

--- a/admin/src/features/project-param-edit/ProjectParamEditDrawer.tsx
+++ b/admin/src/features/project-param-edit/ProjectParamEditDrawer.tsx
@@ -20,6 +20,8 @@ interface ProjectParamEditDrawerProps {
   isHistoryLoading: boolean;
   isRollingBack: boolean;
   onRollbackVersion: (version: ConfigEntryVersion) => void;
+  isReadOnly?: boolean;
+  releaseVersion?: string;
 }
 
 interface FieldRowProps {
@@ -71,6 +73,20 @@ export function ProjectParamEditDrawer(props: ProjectParamEditDrawerProps) {
   const [activeDrawerTab, setActiveDrawerTab] = createSignal<"settings" | "history">("settings");
   const [editVal, setEditVal] = createSignal("");
   const [editDescription, setEditDescription] = createSignal("");
+  const prettyValue = createMemo(() => {
+    const entry = props.entry;
+    if (!entry) return "";
+
+    if (entry.contentType !== "json") {
+      return entry.value;
+    }
+
+    try {
+      return JSON.stringify(JSON.parse(entry.value), null, 2);
+    } catch {
+      return entry.value;
+    }
+  });
 
   createEffect(() => {
     const entry = props.entry;
@@ -116,33 +132,91 @@ export function ProjectParamEditDrawer(props: ProjectParamEditDrawerProps) {
           <div
             data-testid="parameter-edit-drawer"
           >
-            <div class="bg-surface-container/60 mb-5 flex gap-1 rounded-xl p-1">
-              <button
-                type="button"
-                onClick={() => setActiveDrawerTab("settings")}
-                class={`flex-1 cursor-pointer rounded-lg border-0 py-1.5 text-[12px] font-medium transition-all ${
-                  activeDrawerTab() === "settings"
-                    ? "bg-primary text-on-primary"
-                    : "text-outline hover:text-on-surface bg-transparent"
-                }`}
-              >
-                Settings
-              </button>
-              <button
-                type="button"
-                onClick={() => setActiveDrawerTab("history")}
-                class={`flex-1 cursor-pointer rounded-lg border-0 py-1.5 text-[12px] font-medium transition-all ${
-                  activeDrawerTab() === "history"
-                    ? "bg-primary text-on-primary"
-                    : "text-outline hover:text-on-surface bg-transparent"
-                }`}
-              >
-                History ({props.historyVersions.length})
-              </button>
-            </div>
+            <Show when={!props.isReadOnly}>
+              <div class="bg-surface-container/60 mb-5 grid grid-cols-2 gap-1 rounded-xl p-1">
+                <button
+                  type="button"
+                  onClick={() => setActiveDrawerTab("settings")}
+                  class={`min-w-0 cursor-pointer rounded-lg border-0 px-2 py-1.5 text-[11px] font-medium transition-all sm:text-[12px] ${
+                    activeDrawerTab() === "settings"
+                      ? "bg-primary text-on-primary"
+                      : "text-outline hover:text-on-surface bg-transparent"
+                  }`}
+                >
+                  Settings
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setActiveDrawerTab("history")}
+                  class={`min-w-0 cursor-pointer rounded-lg border-0 px-2 py-1.5 text-[11px] font-medium transition-all sm:text-[12px] ${
+                    activeDrawerTab() === "history"
+                      ? "bg-primary text-on-primary"
+                      : "text-outline hover:text-on-surface bg-transparent"
+                  }`}
+                >
+                  <span class="truncate">History</span>
+                  <span class="ml-1 text-[10px] opacity-80 sm:text-[11px]">
+                    ({props.historyVersions.length})
+                  </span>
+                </button>
+              </div>
+            </Show>
 
             <div class="pr-1 pl-1">
-              <Show when={activeDrawerTab() === "settings"}>
+              <Show when={props.isReadOnly}>
+                <div class="grid gap-5 xl:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+                  <div class="space-y-5">
+                    <div class="bg-surface-container-high/40 border-outline-variant/15 flex flex-wrap items-center gap-2 rounded-xl border px-3 py-2.5">
+                      <span class="text-outline text-[11px] font-medium tracking-[0.05em]">
+                        Context
+                      </span>
+                      <span class="bg-primary/10 text-primary border-primary/20 rounded-full border px-2.5 py-0.5 font-mono text-[11px]">
+                        {props.activeEnvName}
+                      </span>
+                      <span class="text-outline/50 text-[11px]">•</span>
+                      <span class="bg-secondary/10 text-secondary border-secondary/20 rounded-full border px-2.5 py-0.5 font-mono text-[11px]">
+                        release {props.releaseVersion}
+                      </span>
+                    </div>
+
+                    <div class="space-y-2">
+                      <Label class="mb-0">Description</Label>
+                      <div class="bg-surface-container-lowest border-outline-variant/20 text-on-surface min-h-[88px] rounded-xl border px-4 py-3 text-[13px] leading-relaxed">
+                        {editDescription().trim() || (
+                          <span class="text-outline/60">No description provided.</span>
+                        )}
+                      </div>
+                    </div>
+
+                    <div class="grid gap-4 sm:grid-cols-2">
+                      <div class="space-y-2">
+                        <Label class="mb-0">Datatype</Label>
+                        <div class="text-primary bg-primary/5 border-primary/15 inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 font-mono text-[11px]">
+                          <MIcon name="data_object" class="text-[14px]" />
+                          {entry.contentType}
+                        </div>
+                      </div>
+
+                      <div class="space-y-2">
+                        <Label class="mb-0">Scope</Label>
+                        <div class="text-secondary bg-secondary/5 border-secondary/15 inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 font-mono text-[11px]">
+                          <MIcon name="public" class="text-[14px]" />
+                          {entry.scope}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <div class="space-y-2">
+                    <Label class="mb-0">Value</Label>
+                    <pre class="bg-surface-container-lowest border-outline-variant/20 text-on-surface min-h-[220px] overflow-x-auto whitespace-pre-wrap break-all rounded-xl border px-4 py-3 font-mono text-[12px] leading-relaxed">
+                      {prettyValue()}
+                    </pre>
+                  </div>
+                </div>
+              </Show>
+
+              <Show when={!props.isReadOnly && activeDrawerTab() === "settings"}>
                 <div class="grid gap-5 xl:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
                   <div class="space-y-5">
                     <div class="bg-surface-container-high/40 border-outline-variant/15 flex flex-wrap items-center gap-2 rounded-xl border px-3 py-2.5">
@@ -231,7 +305,7 @@ export function ProjectParamEditDrawer(props: ProjectParamEditDrawerProps) {
                 </div>
               </Show>
 
-              <Show when={activeDrawerTab() === "history"}>
+              <Show when={!props.isReadOnly && activeDrawerTab() === "history"}>
                 <div>
                   <p class="text-outline mb-5 text-[11px] font-medium tracking-[0.05em]">
                     Version timeline
@@ -358,12 +432,12 @@ export function ProjectParamEditDrawer(props: ProjectParamEditDrawerProps) {
             </div>
 
             <Show
-              when={activeDrawerTab() === "settings"}
+              when={!props.isReadOnly && activeDrawerTab() === "settings"}
               fallback={
                 <div class="border-outline-variant/15 mt-4 flex justify-end border-t pt-4">
                   <Button type="button" variant="outline" onClick={() => props.onClose()}>
                     <MIcon name="close" class="text-[16px]" />
-                    Close
+                    {props.isReadOnly ? "Back" : "Close"}
                   </Button>
                 </div>
               }
@@ -376,6 +450,7 @@ export function ProjectParamEditDrawer(props: ProjectParamEditDrawerProps) {
                     onClick={handleSave}
                     disabled={props.isSaving || isEditInvalid()}
                   >
+                    <MIcon name="save" class="text-[16px]" />
                     {props.isSaving ? "Saving..." : "Save"}
                   </Button>
                 </Show>

--- a/admin/src/features/project-params/ProjectParamsTab.tsx
+++ b/admin/src/features/project-params/ProjectParamsTab.tsx
@@ -53,6 +53,8 @@ interface ProjectParamsTabProps {
   isHistoryLoading: boolean;
   isRollingBack: boolean;
   onRollbackVersion: (version: ConfigEntryVersion) => void;
+  isReadOnly?: boolean;
+  viewingReleaseVersion?: string;
 }
 
 export function ProjectParamsTab(props: ProjectParamsTabProps) {
@@ -72,12 +74,22 @@ export function ProjectParamsTab(props: ProjectParamsTabProps) {
             Parameters
           </p>
           <p class="text-on-surface-variant mt-1 text-xs">
-            Manage configuration parameters for the active environment
-            {props.activeEnvName ? `: ${props.activeEnvName}.` : "."}
+            <Show
+              when={props.isReadOnly && props.viewingReleaseVersion}
+              fallback={
+                <>
+                  Manage configuration parameters for the active environment
+                  {props.activeEnvName ? `: ${props.activeEnvName}.` : "."}
+                </>
+              }
+            >
+              View the parameters captured in release {props.viewingReleaseVersion}
+              {props.activeEnvName ? ` for ${props.activeEnvName}.` : "."}
+            </Show>
           </p>
         </div>
 
-        <div class="flex flex-col gap-2 md:w-auto md:flex-row md:flex-wrap md:items-center md:justify-end">
+        <div class="flex w-full min-w-0 items-center justify-end gap-2 md:w-auto md:flex-row md:flex-wrap md:items-center md:justify-end">
           <Show when={props.activeEnvName && props.configEntries.length > 0}>
             <Input
               data-testid="parameters-search-input"
@@ -87,31 +99,35 @@ export function ProjectParamsTab(props: ProjectParamsTabProps) {
               onInput={(e: InputEvent & { currentTarget: HTMLInputElement }) =>
                 props.onParamSearch(e.currentTarget.value)
               }
-              class="h-10 w-full md:w-72"
+              class="h-10 min-w-0 flex-1 md:w-72"
               leftIcon="search"
-              wrapperStyle="w-full md:w-auto"
+              wrapperStyle="min-w-0 flex-1 md:w-auto md:flex-none"
             />
           </Show>
 
-          <Show when={props.canManage && props.activeEnvName}>
-            <div class="flex flex-wrap gap-2">
+          <Show when={!props.isReadOnly && props.canManage && props.activeEnvName}>
+            <div class="flex flex-wrap justify-end gap-2">
               <button
                 data-testid="project-bulk-import-button"
                 type="button"
-                onClick={props.onToggleBulkImport}
-                class="bg-surface-container-high text-on-surface-variant hover:bg-surface-bright hover:text-on-surface flex cursor-pointer items-center gap-1.5 rounded-lg border-0 px-4 py-2 text-[13px] font-semibold transition-all active:scale-[0.98]"
+                onClick={() => props.onToggleBulkImport()}
+                aria-label="Bulk Import"
+                title="Bulk Import"
+                class="bg-surface-container-high text-on-surface-variant hover:bg-surface-bright hover:text-on-surface inline-flex h-10 w-10 cursor-pointer items-center justify-center rounded-lg border-0 px-0 text-[13px] font-semibold transition-all active:scale-[0.98] md:w-auto md:gap-1.5 md:px-4"
               >
                 <MIcon name="publish" class="text-[17px]" />
-                Bulk Import
+                <span class="hidden md:inline">Bulk Import</span>
               </button>
               <button
                 data-testid="project-add-parameter-button"
                 type="button"
-                onClick={props.onToggleConfigForm}
-                class="bg-primary text-on-primary flex cursor-pointer items-center gap-1.5 rounded-lg border-0 px-4 py-2 text-[13px] font-semibold transition-all hover:brightness-105 active:scale-[0.98]"
+                onClick={() => props.onToggleConfigForm()}
+                aria-label="Add Parameter"
+                title="Add Parameter"
+                class="bg-primary text-on-primary inline-flex h-10 w-10 cursor-pointer items-center justify-center self-end rounded-lg border-0 px-0 text-[13px] font-semibold transition-all hover:brightness-105 active:scale-[0.98] md:w-auto md:gap-1.5 md:px-4 md:self-auto"
               >
-                <MIcon name="add" class="text-[17px]" />
-                Add Parameter
+                <MIcon name="add" class="text-[16px]" />
+                <span class="hidden md:inline">Add Parameter</span>
               </button>
             </div>
           </Show>
@@ -120,7 +136,7 @@ export function ProjectParamsTab(props: ProjectParamsTabProps) {
 
       {props.bulkImportPanel}
 
-      <Show when={props.canManage && props.activeEnvName && props.showConfigForm}>
+      <Show when={!props.isReadOnly && props.canManage && props.activeEnvName && props.showConfigForm}>
         <ProjectParamCreateForm
           onCancel={props.onCancelCreate}
           onSubmit={props.onSubmitCreate}
@@ -158,12 +174,19 @@ export function ProjectParamsTab(props: ProjectParamsTabProps) {
           isRollingBack={props.isRollingBack}
           onRollbackVersion={props.onRollbackVersion}
           search={props.paramSearch}
+          isReadOnly={props.isReadOnly}
+          releaseVersion={props.viewingReleaseVersion}
         />
       </Show>
 
       <Show when={props.activeEnvName && !props.isLoading && props.filteredConfig.length === 0}>
         <div class="bg-surface-container rounded-xl px-4 py-5 text-center text-xs text-on-surface-variant">
-          No parameters yet for this environment
+          <Show
+            when={props.isReadOnly && props.viewingReleaseVersion}
+            fallback={<>No parameters yet for this environment</>}
+          >
+            No parameters were captured in release {props.viewingReleaseVersion}
+          </Show>
         </div>
       </Show>
     </section>

--- a/admin/src/features/project-params/ProjectParamsTable.tsx
+++ b/admin/src/features/project-params/ProjectParamsTable.tsx
@@ -1,4 +1,4 @@
-import { For, Show, createMemo } from "solid-js";
+import { For, Show, createMemo, createSignal, onCleanup, onMount } from "solid-js";
 import { ProjectParamEditDrawer } from "../project-param-edit/ProjectParamEditDrawer";
 import { MIcon } from "../../shared/ui/icons";
 import type { ConfigEntry, ConfigEntryVersion } from "../../types";
@@ -29,6 +29,8 @@ interface ProjectParamsTableProps {
   isRollingBack: boolean;
   onRollbackVersion: (version: ConfigEntryVersion) => void;
   search: string;
+  isReadOnly?: boolean;
+  releaseVersion?: string;
 }
 
 const TYPE_STYLE: Record<string, string> = {
@@ -45,9 +47,185 @@ const SCOPE_STYLE: Record<string, string> = {
 };
 
 export function ProjectParamsTable(props: ProjectParamsTableProps) {
+  const [isMobile, setIsMobile] = createSignal(false);
+
+  onMount(() => {
+    const syncViewport = () => setIsMobile(window.innerWidth < 768);
+
+    syncViewport();
+    window.addEventListener("resize", syncViewport);
+    onCleanup(() => window.removeEventListener("resize", syncViewport));
+  });
+
+  const renderEditor = () => (
+    <ProjectParamEditDrawer
+      entry={props.editingEntry}
+      activeEnvName={props.activeEnvName}
+      initialDescription={props.initialDescription}
+      onClose={props.onCloseEntry}
+      onSaveSettings={props.onSaveSettings}
+      isSaving={props.isSaving}
+      canManage={props.canManage}
+      historyVersions={props.historyVersions}
+      isHistoryLoading={props.isHistoryLoading}
+      isRollingBack={props.isRollingBack}
+      onRollbackVersion={props.onRollbackVersion}
+      isReadOnly={props.isReadOnly}
+      releaseVersion={props.releaseVersion}
+    />
+  );
+
   return (
-    <div class="bg-surface-container-low border-outline-variant/15 overflow-hidden rounded-xl border">
-      <div class="overflow-x-auto">
+    <div class="space-y-3">
+      <Show when={isMobile()}>
+        <div class="space-y-3">
+        <Show when={props.isLoading}>
+          <For each={[1, 2, 3]}>
+            {() => <div class="skeleton h-36 w-full rounded-2xl" />}
+          </For>
+        </Show>
+
+        <Show when={!props.isLoading}>
+          <For each={props.filteredConfig}>
+            {entry => {
+              const meta = createMemo(() =>
+                props.getParamMeta(props.projectId, props.activeEnvName, entry.key)
+              );
+              const isExpanded = () => props.editingEntry?.key === entry.key;
+
+              return (
+                <article class="bg-surface-container border-outline-variant/10 overflow-hidden rounded-2xl border">
+                  <div
+                    data-testid={`parameter-row-${entry.key}`}
+                    role="button"
+                    tabindex="0"
+                    onClick={() => props.onSelectEntry(entry)}
+                    onKeyDown={event => {
+                      if (event.key === "Enter" || event.key === " ") {
+                        event.preventDefault();
+                        props.onSelectEntry(entry);
+                      }
+                    }}
+                    class="w-full cursor-pointer border-0 bg-transparent p-4 text-left"
+                  >
+                    <div class="flex items-start gap-3">
+                      <div
+                        class={`bg-surface-container-high text-outline mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-lg transition-transform ${
+                          isExpanded() ? "rotate-180" : ""
+                        }`}
+                      >
+                        <MIcon name="expand_more" class="text-[16px]" />
+                      </div>
+
+                      <div class="min-w-0 flex-1 space-y-3">
+                        <div class="min-w-0">
+                          <span
+                            data-testid={`parameter-display-${entry.key}`}
+                            class="text-on-surface block text-[13.5px] font-bold"
+                          >
+                            {meta().displayName}
+                          </span>
+                          <span
+                            data-testid={`parameter-key-${entry.key}`}
+                            class="text-outline mt-0.5 block font-mono text-[10px] tracking-tight break-all"
+                          >
+                            {entry.key}
+                          </span>
+                        </div>
+
+                        <div class="flex flex-wrap gap-2">
+                          <span
+                            class={`rounded-full px-2 py-0.5 text-[9px] font-bold tracking-wider uppercase ${
+                              TYPE_STYLE[entry.contentType] ?? ""
+                            }`}
+                          >
+                            {entry.contentType}
+                          </span>
+                          <span
+                            class={`rounded-full px-2 py-0.5 text-[9px] font-bold tracking-wider uppercase ${
+                              SCOPE_STYLE[entry.scope] ?? ""
+                            }`}
+                          >
+                            {entry.scope}
+                          </span>
+                        </div>
+
+                        <div
+                          class="bg-surface-container-lowest/60 flex items-center gap-2 rounded-xl px-3 py-2"
+                          onClick={e => e.stopPropagation()}
+                        >
+                          <span
+                            data-testid={`parameter-value-${entry.key}`}
+                            class="text-on-surface-variant min-w-0 flex-1 truncate font-mono text-[12px]"
+                          >
+                            {entry.value}
+                          </span>
+                          <button
+                            type="button"
+                            onClick={() => void props.onCopyValue(entry.key, entry.value)}
+                            title="Copy value"
+                            class="text-outline hover:text-primary hover:bg-primary/10 flex shrink-0 cursor-pointer items-center justify-center rounded border-0 bg-transparent p-1"
+                          >
+                            <MIcon
+                              name={props.copiedKey === entry.key ? "check" : "content_copy"}
+                              class="text-[14px]"
+                            />
+                          </button>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+
+                  <Show when={props.canManage}>
+                    <div class="border-outline-variant/10 flex justify-end gap-1 border-t px-4 py-2">
+                      <button
+                        data-testid={`parameter-share-${entry.key}`}
+                        type="button"
+                        onClick={() => props.onShareEntry(entry)}
+                        class="text-outline hover:text-primary hover:bg-primary/10 cursor-pointer rounded-lg border-0 bg-transparent p-1.5"
+                        title={`Share parameter ${entry.key}`}
+                        aria-label={`Share parameter ${entry.key}`}
+                      >
+                        <MIcon name="ios_share" class="text-[18px]" />
+                      </button>
+                      <button
+                        data-testid={`parameter-delete-${entry.key}`}
+                        type="button"
+                        onClick={() => props.onDeleteEntry(entry.key)}
+                        class="text-outline hover:text-error hover:bg-error/10 cursor-pointer rounded-lg border-0 bg-transparent p-1.5"
+                        title={`Delete parameter ${entry.key}`}
+                        aria-label={`Delete parameter ${entry.key}`}
+                      >
+                        <MIcon name="delete_outline" class="text-[18px]" />
+                      </button>
+                    </div>
+                  </Show>
+
+                  <Show when={isExpanded()}>
+                    <div
+                      data-testid={`parameter-accordion-${entry.key}`}
+                      class="bg-surface-container-lowest/30 border-outline-variant/10 border-t px-4 py-4"
+                    >
+                      {renderEditor()}
+                    </div>
+                  </Show>
+                </article>
+              );
+            }}
+          </For>
+        </Show>
+
+        <Show when={!props.isLoading && props.search && props.filteredConfig.length === 0}>
+          <div class="text-on-surface-variant py-10 text-center text-sm">
+            No parameters match "<span class="text-on-surface font-medium">{props.search}</span>"
+          </div>
+        </Show>
+        </div>
+      </Show>
+
+      <Show when={!isMobile()}>
+        <div class="bg-surface-container-low border-outline-variant/15 overflow-hidden rounded-xl border">
+        <div class="overflow-x-auto">
         <table class="w-full border-collapse text-left text-[12px]">
           <thead class="sticky top-0 z-10">
             <tr class="border-outline-variant/15 bg-surface-container-lowest/50 border-b">
@@ -64,7 +242,9 @@ export function ProjectParamsTable(props: ProjectParamsTableProps) {
                 Scope
               </th>
               <th class="text-outline w-24 px-6 py-3 text-right text-[11px] font-medium tracking-[0.05em] uppercase">
-                Actions
+                <Show when={!props.isReadOnly} fallback={<>Details</>}>
+                  Actions
+                </Show>
               </th>
             </tr>
           </thead>
@@ -198,19 +378,7 @@ export function ProjectParamsTable(props: ProjectParamsTableProps) {
                       <Show when={isExpanded()}>
                         <tr data-testid={`parameter-accordion-${entry.key}`}>
                           <td colspan="5" class="bg-surface-container-lowest/30 px-6 py-4">
-                            <ProjectParamEditDrawer
-                              entry={props.editingEntry}
-                              activeEnvName={props.activeEnvName}
-                              initialDescription={props.initialDescription}
-                              onClose={props.onCloseEntry}
-                              onSaveSettings={props.onSaveSettings}
-                              isSaving={props.isSaving}
-                              canManage={props.canManage}
-                              historyVersions={props.historyVersions}
-                              isHistoryLoading={props.isHistoryLoading}
-                              isRollingBack={props.isRollingBack}
-                              onRollbackVersion={props.onRollbackVersion}
-                            />
+                            {renderEditor()}
                           </td>
                         </tr>
                       </Show>
@@ -229,7 +397,9 @@ export function ProjectParamsTable(props: ProjectParamsTableProps) {
             </Show>
           </tbody>
         </table>
-      </div>
+        </div>
+        </div>
+      </Show>
     </div>
   );
 }

--- a/admin/src/features/project-releases/ProjectReleases.tsx
+++ b/admin/src/features/project-releases/ProjectReleases.tsx
@@ -1,7 +1,4 @@
-import { For, Show, createMemo, createSignal } from "solid-js";
-import { Button } from "../../shared/ui/button";
-import { Input } from "../../shared/ui/input";
-import { Label } from "../../shared/ui/label";
+import { For, Show, createMemo } from "solid-js";
 import { MIcon } from "../../shared/ui/icons";
 import type { ConfigRelease } from "../../types";
 
@@ -10,45 +7,22 @@ interface ProjectReleasesProps {
   activeReleaseVersion?: string | null;
   releases: ConfigRelease[];
   isLoading: boolean;
-  isPublishing: boolean;
   isActivating: boolean;
-  draftingVersion: string | null;
+  amendingVersion: string | null;
   deletingVersion: string | null;
   canManage: boolean;
-  onPublish: (version: string, makeActive: boolean) => Promise<unknown>;
+  onCreateVersion: () => void;
+  onView: (version: string) => void;
+  onAmend: (version: string) => void;
   onActivate: (version: string) => void;
   onClearActive: () => void;
-  onDraft: (version: string) => void;
   onDelete: (version: string) => void;
 }
 
-const exactVersionPattern = /^\d+\.\d+\.\d+$/;
-
 export function ProjectReleases(props: ProjectReleasesProps) {
-  const [version, setVersion] = createSignal("");
-  const [makeActive, setMakeActive] = createSignal(true);
-  const [error, setError] = createSignal("");
-
   const activeRelease = createMemo(() =>
     props.releases.find(release => release.version === props.activeReleaseVersion)
   );
-
-  const handlePublish = async (event: Event) => {
-    event.preventDefault();
-    const trimmed = version().trim();
-    if (!exactVersionPattern.test(trimmed)) {
-      setError("Use major.minor.patch.");
-      return;
-    }
-
-    setError("");
-    try {
-      await props.onPublish(trimmed, makeActive());
-      setVersion("");
-    } catch {
-      return;
-    }
-  };
 
   return (
     <section
@@ -56,88 +30,58 @@ export function ProjectReleases(props: ProjectReleasesProps) {
       data-testid="project-releases-section"
       class="bg-surface-container-low border-outline-variant/15 space-y-4 rounded-2xl border p-5 scroll-mt-20"
     >
-      <div>
-        <p
-          data-testid="project-releases-heading"
-          class="text-outline font-headline flex items-center gap-1.5 text-[10px] font-bold tracking-widest uppercase"
-        >
-          <MIcon name="deployed_code_history" class="text-[15px]" />
-          Releases
-        </p>
-        <div class="mt-1 flex flex-wrap items-center gap-2 text-xs">
-          <span class="text-on-surface-variant">
-            Publish and activate releases for the active environment: {props.environmentName}.
-          </span>
-          <span class="text-on-surface-variant">Active release:</span>
-          <Show
-            when={activeRelease()}
-            fallback={<span class="text-outline font-mono">none</span>}
+      <div class="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+        <div>
+          <p
+            data-testid="project-releases-heading"
+            class="text-outline font-headline flex items-center gap-1.5 text-[10px] font-bold tracking-widest uppercase"
           >
-            {release => (
-              <span class="bg-primary/10 text-primary rounded-md px-2 py-0.5 font-mono text-[11px] font-bold">
-                {release().version}
-              </span>
-            )}
-          </Show>
-          <Show when={props.canManage && props.activeReleaseVersion}>
-            <button
-              type="button"
-              onClick={() => props.onClearActive()}
-              disabled={props.isActivating}
-              class="text-on-surface-variant hover:text-on-surface cursor-pointer border-0 bg-transparent p-0 text-[12px] font-semibold disabled:opacity-50"
+            <MIcon name="deployed_code_history" class="text-[15px]" />
+            Releases
+          </p>
+          <div class="mt-1 flex flex-wrap items-center gap-2 text-xs">
+            <span class="text-on-surface-variant">
+              Publish immutable snapshots for {props.environmentName}, then activate one for clients.
+            </span>
+            <span class="text-on-surface-variant">Active release:</span>
+            <Show
+              when={activeRelease()}
+              fallback={<span class="text-outline font-mono">none</span>}
             >
-              Clear
-            </button>
-          </Show>
-        </div>
-      </div>
-
-      <Show when={props.canManage}>
-        <form
-          onSubmit={handlePublish}
-          class="bg-surface-container border-outline-variant/15 grid gap-3 rounded-2xl border p-4 shadow-sm md:grid-cols-[minmax(180px,1fr)_auto]"
-        >
-          <div class="space-y-2">
-            <div>
-              <Label for="release-version-input">Version</Label>
-              <Input
-                data-testid="release-version-input"
-                id="release-version-input"
-                aria-label="Release version"
-                value={version()}
-                onInput={event => {
-                  setVersion(event.currentTarget.value);
-                  if (error()) setError("");
-                }}
-                placeholder="1.1.0"
-                class="font-mono"
-              />
-            </div>
-            <label class="text-on-surface-variant flex cursor-pointer items-center gap-2 text-[12px]">
-              <input
-                type="checkbox"
-                checked={makeActive()}
-                onChange={event => setMakeActive(event.currentTarget.checked)}
-                class="accent-primary"
-              />
-              Set active after publish
-            </label>
-            <Show when={error()}>
-              <p class="text-error text-[11px] font-bold">{error()}</p>
+              {release => (
+                <span class="bg-primary/10 text-primary rounded-md px-2 py-0.5 font-mono text-[11px] font-bold">
+                  {release().version}
+                </span>
+              )}
+            </Show>
+            <Show when={props.canManage && props.activeReleaseVersion}>
+              <button
+                type="button"
+                onClick={() => props.onClearActive()}
+                disabled={props.isActivating}
+                class="text-on-surface-variant hover:text-on-surface cursor-pointer border-0 bg-transparent p-0 text-[12px] font-semibold disabled:opacity-50"
+              >
+                Clear
+              </button>
             </Show>
           </div>
-          <div class="flex items-center justify-end">
-            <Button
-              data-testid="release-publish-button"
-              type="submit"
-              disabled={props.isPublishing || !props.environmentName}
-            >
-              <MIcon name="add" class="text-[16px]" />
-              {props.isPublishing ? "Publishing" : "Create"}
-            </Button>
-          </div>
-        </form>
-      </Show>
+        </div>
+
+        <Show when={props.canManage}>
+          <button
+            data-testid="release-create-version-button"
+            type="button"
+            onClick={() => props.onCreateVersion()}
+            disabled={!props.environmentName}
+            aria-label="Create a version"
+            title="Create a version"
+            class="bg-primary text-on-primary inline-flex h-10 w-10 shrink-0 cursor-pointer items-center justify-center gap-1.5 self-end rounded-lg border-0 px-0 text-[13px] font-semibold transition-all hover:brightness-105 active:scale-[0.98] disabled:opacity-50 md:h-10 md:w-auto md:px-4 md:self-auto"
+          >
+            <MIcon name="add" class="text-[17px]" />
+            <span class="hidden md:inline">Create a version</span>
+          </button>
+        </Show>
+      </div>
 
       <Show
         when={!props.isLoading}
@@ -172,26 +116,43 @@ export function ProjectReleases(props: ProjectReleasesProps) {
                     <p class="text-outline mt-0.5 text-[11px]">Published by {release.actor}</p>
                   </div>
 
-                  <Show when={props.canManage}>
-                    <div class="flex flex-wrap items-center justify-end gap-2">
+                  <div class="flex flex-wrap items-center justify-end gap-2">
+                    <button
+                      data-testid={`release-view-${release.version}`}
+                      type="button"
+                      onClick={() => props.onView(release.version)}
+                      aria-label={`View parameters for release ${release.version}`}
+                      title={`View parameters for release ${release.version}`}
+                      class="bg-surface-container-high text-on-surface hover:bg-surface-bright inline-flex h-9 w-9 cursor-pointer items-center justify-center gap-1.5 rounded-lg border-0 px-0 text-[12px] font-semibold disabled:cursor-default disabled:opacity-50 md:w-auto md:px-3"
+                    >
+                      <MIcon name="visibility" class="text-[15px]" />
+                      <span class="hidden md:inline">View parameters</span>
+                    </button>
+                    <Show when={props.canManage}>
                       <button
                         type="button"
                         onClick={() => props.onActivate(release.version)}
                         disabled={props.isActivating || release.isActive}
-                        class="bg-surface-container-high text-on-surface hover:bg-surface-bright inline-flex h-9 cursor-pointer items-center gap-1.5 rounded-lg border-0 px-3 text-[12px] font-semibold disabled:cursor-default disabled:opacity-50"
+                        aria-label={`Activate release ${release.version}`}
+                        title={`Activate release ${release.version}`}
+                        class="bg-surface-container-high text-on-surface hover:bg-surface-bright inline-flex h-9 w-9 cursor-pointer items-center justify-center gap-1.5 rounded-lg border-0 px-0 text-[12px] font-semibold disabled:cursor-default disabled:opacity-50 md:w-auto md:px-3"
                       >
                         <MIcon name="check_circle" class="text-[15px]" />
-                        Activate
+                        <span class="hidden md:inline">Activate</span>
                       </button>
                       <button
-                        data-testid={`release-draft-${release.version}`}
+                        data-testid={`release-amend-${release.version}`}
                         type="button"
-                        onClick={() => props.onDraft(release.version)}
-                        disabled={props.draftingVersion !== null}
-                        class="bg-surface-container-high text-on-surface hover:bg-surface-bright inline-flex h-9 cursor-pointer items-center gap-1.5 rounded-lg border-0 px-3 text-[12px] font-semibold disabled:opacity-50"
+                        onClick={() => props.onAmend(release.version)}
+                        disabled={props.amendingVersion !== null}
+                        aria-label={`Amend release ${release.version}`}
+                        class="bg-surface-container-high text-on-surface hover:bg-surface-bright inline-flex h-9 w-9 cursor-pointer items-center justify-center gap-1.5 rounded-lg border-0 px-0 text-[12px] font-semibold md:w-auto md:px-3"
+                        title={`Amend release ${release.version} as a new patch`}
                       >
-                        <MIcon name="edit_document" class="text-[15px]" />
-                        {props.draftingVersion === release.version ? "Drafting" : "Draft"}
+                        <MIcon name="edit" class="text-[15px]" />
+                        <span class="hidden md:inline">
+                          {props.amendingVersion === release.version ? "Amending" : "Amend"}
+                        </span>
                       </button>
                       <button
                         data-testid={`release-delete-${release.version}`}
@@ -203,13 +164,16 @@ export function ProjectReleases(props: ProjectReleasesProps) {
                             ? "Clear the active release before deleting it"
                             : `Delete release ${release.version}`
                         }
-                        class="bg-error-container/10 text-error hover:bg-error-container/20 inline-flex h-9 cursor-pointer items-center gap-1.5 rounded-lg border-0 px-3 text-[12px] font-semibold disabled:cursor-default disabled:opacity-50"
+                        aria-label={`Delete release ${release.version}`}
+                        class="bg-error-container/10 text-error hover:bg-error-container/20 inline-flex h-9 w-9 cursor-pointer items-center justify-center gap-1.5 rounded-lg border-0 px-0 text-[12px] font-semibold disabled:cursor-default disabled:opacity-50 md:w-auto md:px-3"
                       >
                         <MIcon name="delete" class="text-[15px]" />
-                        {props.deletingVersion === release.version ? "Deleting" : "Delete"}
+                        <span class="hidden md:inline">
+                          {props.deletingVersion === release.version ? "Deleting" : "Delete"}
+                        </span>
                       </button>
-                    </div>
-                  </Show>
+                    </Show>
+                  </div>
                 </div>
               )}
             </For>

--- a/admin/src/features/project-releases/ReleaseVersionDialog.tsx
+++ b/admin/src/features/project-releases/ReleaseVersionDialog.tsx
@@ -1,0 +1,138 @@
+import { createEffect, type JSXElement, Show } from "solid-js";
+import { createSignal } from "solid-js";
+import { Portal } from "solid-js/web";
+import { Button } from "../../shared/ui/button";
+import { MIcon } from "../../shared/ui/icons";
+import { Input } from "../../shared/ui/input";
+import { Label } from "../../shared/ui/label";
+
+const exactVersionPattern = /^\d+\.\d+\.\d+$/;
+const majorMinorPattern = /^\d+\.\d+$/;
+
+interface ReleaseVersionDialogProps {
+  open: boolean;
+  title: string;
+  description?: JSXElement;
+  initialVersion: string;
+  /** Existing release versions, used to prevent collisions. */
+  existingVersions: string[];
+  confirmLabel: string;
+  placeholder?: string;
+  validationMessage?: string;
+  versionFormat?: "semver" | "majorMinor";
+  normalizeVersion?: (version: string) => string;
+  isPending?: boolean;
+  onConfirm: (version: string) => void;
+  onCancel: () => void;
+}
+
+export function ReleaseVersionDialog(props: ReleaseVersionDialogProps) {
+  const [version, setVersion] = createSignal(props.initialVersion);
+  const [error, setError] = createSignal("");
+
+  // Reset the field whenever the dialog opens or its seed version changes.
+  createEffect(() => {
+    if (props.open) {
+      setVersion(props.initialVersion);
+      setError("");
+    }
+  });
+
+  const submit = () => {
+    const trimmed = version().trim();
+    const versionFormat = props.versionFormat ?? "semver";
+    const isValid =
+      versionFormat === "majorMinor"
+        ? majorMinorPattern.test(trimmed)
+        : exactVersionPattern.test(trimmed);
+
+    if (!isValid) {
+      setError(props.validationMessage ?? "Use major.minor.patch.");
+      return;
+    }
+
+    const normalizedVersion = props.normalizeVersion ? props.normalizeVersion(trimmed) : trimmed;
+
+    if (
+      props.existingVersions.some(v => v.toLowerCase() === normalizedVersion.toLowerCase())
+    ) {
+      setError("That version already exists.");
+      return;
+    }
+    setError("");
+    props.onConfirm(normalizedVersion);
+  };
+
+  return (
+    <Show when={props.open}>
+      <Portal>
+        <div
+          data-testid="release-version-dialog"
+          class="animate-backdrop-in fixed inset-0 z-80 flex items-center justify-center bg-black/60 p-4 backdrop-blur-sm"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="release-version-dialog-title"
+          onClick={e => {
+            if (e.target === e.currentTarget && !props.isPending) props.onCancel();
+          }}
+        >
+          <div class="bg-surface-container-low border-outline-variant/15 animate-palette-in w-full max-w-md rounded-2xl border p-8 shadow-2xl">
+            <h3
+              id="release-version-dialog-title"
+              class="font-headline text-on-surface mb-2 text-base font-bold"
+            >
+              {props.title}
+            </h3>
+            <Show when={props.description}>
+              <p class="text-on-surface-variant mb-5 text-sm leading-relaxed">{props.description}</p>
+            </Show>
+
+            <div>
+              <Label for="release-version-input">Version</Label>
+              <Input
+                data-testid="release-version-input"
+                id="release-version-input"
+                autofocus
+                value={version()}
+                onInput={event => {
+                  setVersion(event.currentTarget.value);
+                  if (error()) setError("");
+                }}
+                onKeyDown={(event: KeyboardEvent) => {
+                  if (event.key === "Enter" && !props.isPending) submit();
+                }}
+                placeholder={props.placeholder ?? "1.0.0"}
+                class="font-mono"
+              />
+              <Show when={error()}>
+                <p class="text-error mt-2 text-[11px] font-bold">{error()}</p>
+              </Show>
+            </div>
+
+            <div class="mt-6 flex justify-end gap-3">
+              <Button
+                data-testid="release-version-confirm-button"
+                type="button"
+                onClick={submit}
+                disabled={props.isPending}
+              >
+                <MIcon name="arrow_forward" class="text-[16px]" />
+                {props.isPending ? "Please wait…" : props.confirmLabel}
+              </Button>
+              <Button
+                data-testid="release-version-cancel-button"
+                type="button"
+                variant="outline"
+                onClick={() => props.onCancel()}
+                disabled={props.isPending}
+              >
+                <MIcon name="close" class="text-[16px]" />
+                Cancel
+              </Button>
+            </div>
+          </div>
+        </div>
+      </Portal>
+    </Show>
+  );
+}

--- a/admin/src/pages/audit-logs/AuditLogsPage.tsx
+++ b/admin/src/pages/audit-logs/AuditLogsPage.tsx
@@ -182,7 +182,14 @@ export default function AuditLogsPage() {
           data-testid="audit-logs-section"
           class="bg-surface-container-low border-outline-variant/15 space-y-4 rounded-2xl border p-5"
         >
-          <AuditLogsHeader onExport={exportLogs} />
+          <AuditLogsHeader
+            onExport={exportLogs}
+            search={search()}
+            setSearch={v => {
+              setSearch(v);
+              setPage(0);
+            }}
+          />
 
           <Show when={auditQuery.isError}>
             <QueryErrorBanner
@@ -220,6 +227,7 @@ export default function AuditLogsPage() {
           uniqueActions={uniqueActions()}
           uniqueEnvs={uniqueEnvs()}
           clearAllFilters={clearFilters}
+          hideSearch
         />
 
         <AuditLogsTable

--- a/admin/src/pages/audit-logs/components/AuditLogsFilters.tsx
+++ b/admin/src/pages/audit-logs/components/AuditLogsFilters.tsx
@@ -19,6 +19,7 @@ interface AuditLogsFiltersProps {
   uniqueActions: string[];
   uniqueEnvs: string[];
   clearAllFilters: () => void;
+  hideSearch?: boolean;
 }
 
 export function AuditLogsFilters(props: AuditLogsFiltersProps) {
@@ -102,21 +103,25 @@ export function AuditLogsFilters(props: AuditLogsFiltersProps) {
     <div class="space-y-4">
       {/* Search and drop-down filters */}
       <div class="flex flex-wrap items-center gap-4">
-        <Input
-          data-testid="audit-search-input"
-          type="text"
-          placeholder="Filter audit trail..."
-          value={props.search}
-          onInput={e => props.setSearch(e.currentTarget.value)}
-          class="h-10 w-56"
-          leftIcon="search"
-          wrapperStyle="w-auto"
-        />
-        <span class="text-outline/70 shrink-0 text-[11px] font-medium">Filters:</span>
+        <Show when={!props.hideSearch}>
+          <Input
+            data-testid="audit-search-input"
+            type="text"
+            placeholder="Filter audit trail..."
+            value={props.search}
+            onInput={e => props.setSearch(e.currentTarget.value)}
+            class="h-10 w-56"
+            leftIcon="search"
+            wrapperStyle="w-auto"
+          />
+        </Show>
+        <span class="text-outline/70 hidden shrink-0 text-[11px] font-medium sm:inline">
+          Filters:
+        </span>
 
-        <div class="flex gap-2">
+        <div class="grid w-full min-w-0 grid-cols-2 gap-2 sm:flex sm:w-auto">
           {/* Action Type filter */}
-          <div class="w-44">
+          <div class="min-w-0 sm:w-44">
             <Select
               value={props.filterAction === "all" ? "" : props.filterAction}
               onChange={val => props.setFilterAction(val)}
@@ -127,7 +132,7 @@ export function AuditLogsFilters(props: AuditLogsFiltersProps) {
           </div>
 
           {/* Environment filter */}
-          <div class="w-44">
+          <div class="min-w-0 sm:w-44">
             <Select
               value={props.filterEnv === "all" ? "" : props.filterEnv}
               onChange={val => props.setFilterEnv(val)}
@@ -140,7 +145,7 @@ export function AuditLogsFilters(props: AuditLogsFiltersProps) {
 
         <button
           onClick={() => props.clearAllFilters()}
-          class="text-outline hover:text-error flex cursor-pointer items-center gap-1 border-0 bg-transparent text-[11px] font-medium transition-colors"
+          class="text-outline hover:text-error ml-auto flex cursor-pointer items-center gap-1 border-0 bg-transparent text-[11px] font-medium transition-colors sm:ml-0"
         >
           <MIcon name="close" class="text-[14px]" />
           Clear

--- a/admin/src/pages/audit-logs/components/AuditLogsHeader.tsx
+++ b/admin/src/pages/audit-logs/components/AuditLogsHeader.tsx
@@ -1,8 +1,11 @@
 import { createSignal, Show } from "solid-js";
 import { MIcon } from "../../../shared/ui/icons";
+import { Input } from "../../../shared/ui/input";
 
 interface AuditLogsHeaderProps {
   onExport: (format: "csv" | "json") => void;
+  search: string;
+  setSearch: (value: string) => void;
 }
 
 export function AuditLogsHeader(props: AuditLogsHeaderProps) {
@@ -22,40 +25,53 @@ export function AuditLogsHeader(props: AuditLogsHeaderProps) {
           All administrative actions across your organization.
         </p>
       </div>
-      <div class="relative">
-        <button
-          data-testid="audit-export-button"
-          onClick={() => setShowExportMenu(v => !v)}
-          class="bg-primary text-on-primary flex shrink-0 cursor-pointer items-center gap-1.5 rounded-lg border-0 px-4 py-2 text-[13px] font-semibold transition-all hover:brightness-105 active:scale-[0.98]"
-        >
-          <MIcon name="download" class="text-[18px]" />
-          Export Logs
-          <MIcon name="arrow_drop_down" class="text-[16px]" />
-        </button>
-        <Show when={showExportMenu()}>
-          <div class="bg-surface-container-low border-outline-variant/20 animate-fade-in absolute top-full right-0 z-50 mt-1.5 min-w-40 overflow-hidden rounded-lg border shadow-xl">
-            <button
-              onClick={() => {
-                props.onExport("csv");
-                setShowExportMenu(false);
-              }}
-              class="text-on-surface hover:bg-surface-container-high flex w-full cursor-pointer items-center gap-2.5 border-0 bg-transparent px-4 py-2.5 text-[13px] transition-colors"
-            >
-              <MIcon name="table_view" class="text-outline text-[16px]" />
-              Export CSV
-            </button>
-            <button
-              onClick={() => {
-                props.onExport("json");
-                setShowExportMenu(false);
-              }}
-              class="text-on-surface hover:bg-surface-container-high flex w-full cursor-pointer items-center gap-2.5 border-0 bg-transparent px-4 py-2.5 text-[13px] transition-colors"
-            >
-              <MIcon name="data_object" class="text-outline text-[16px]" />
-              Export JSON
-            </button>
-          </div>
-        </Show>
+      <div class="flex w-full min-w-0 items-center justify-end gap-2 md:w-auto md:flex-row md:flex-wrap md:items-center md:justify-end">
+        <Input
+          data-testid="audit-search-input"
+          type="text"
+          placeholder="Filter audit trail..."
+          value={props.search}
+          onInput={e => props.setSearch(e.currentTarget.value)}
+          class="h-10 min-w-0 flex-1 md:w-64"
+          leftIcon="search"
+          wrapperStyle="min-w-0 flex-1 md:w-auto md:flex-none"
+        />
+        <div class="relative">
+          <button
+            data-testid="audit-export-button"
+            onClick={() => setShowExportMenu(v => !v)}
+            aria-label="Export Logs"
+            title="Export Logs"
+            class="bg-primary text-on-primary inline-flex h-10 w-10 shrink-0 cursor-pointer items-center justify-center gap-1.5 rounded-lg border-0 px-0 text-[13px] font-semibold transition-all hover:brightness-105 active:scale-[0.98] md:h-10 md:w-auto md:px-4"
+          >
+            <MIcon name="download" class="text-[18px]" />
+            <span class="hidden md:inline">Export Logs</span>
+          </button>
+          <Show when={showExportMenu()}>
+            <div class="bg-surface-container-low border-outline-variant/20 animate-fade-in absolute top-full right-0 z-50 mt-1.5 min-w-40 overflow-hidden rounded-lg border shadow-xl">
+              <button
+                onClick={() => {
+                  props.onExport("csv");
+                  setShowExportMenu(false);
+                }}
+                class="text-on-surface hover:bg-surface-container-high flex w-full cursor-pointer items-center gap-2.5 border-0 bg-transparent px-4 py-2.5 text-[13px] transition-colors"
+              >
+                <MIcon name="table_view" class="text-outline text-[16px]" />
+                Export CSV
+              </button>
+              <button
+                onClick={() => {
+                  props.onExport("json");
+                  setShowExportMenu(false);
+                }}
+                class="text-on-surface hover:bg-surface-container-high flex w-full cursor-pointer items-center gap-2.5 border-0 bg-transparent px-4 py-2.5 text-[13px] transition-colors"
+              >
+                <MIcon name="data_object" class="text-outline text-[16px]" />
+                Export JSON
+              </button>
+            </div>
+          </Show>
+        </div>
       </div>
     </div>
   );

--- a/admin/src/pages/auth/LoginPage.tsx
+++ b/admin/src/pages/auth/LoginPage.tsx
@@ -1,4 +1,4 @@
-import { A, type RouteSectionProps, useNavigate } from "@solidjs/router";
+import { type RouteSectionProps, useNavigate } from "@solidjs/router";
 import { useMutation, useQuery } from "@tanstack/solid-query";
 import { createEffect, createSignal, Show } from "solid-js";
 import { authService } from "../../entities/auth/api/auth.service";
@@ -247,16 +247,7 @@ export default function LoginPage(props: LoginPageProps = {}) {
             </div>
           </form>
 
-          <div class="mt-5 flex items-center justify-between text-[12px]">
-            <span class="text-on-surface-variant">
-              Don't have an account?{" "}
-              <A
-                href="/register"
-                class="text-primary hover:text-primary/80 font-bold transition-colors hover:underline"
-              >
-                Register
-              </A>
-            </span>
+          <div class="mt-5 flex items-center justify-end text-[12px]">
             <button
               data-testid="forgot-open-button"
               type="button"

--- a/admin/src/pages/projects/ProjectPage.tsx
+++ b/admin/src/pages/projects/ProjectPage.tsx
@@ -1,7 +1,7 @@
 import { writeClipboard } from "@solid-primitives/clipboard";
 import { createTimer } from "@solid-primitives/timer";
 import { Title } from "@solidjs/meta";
-import { useParams } from "@solidjs/router";
+import { useNavigate, useParams, useSearchParams } from "@solidjs/router";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/solid-query";
 import { Show, createEffect, createMemo, createSignal } from "solid-js";
 
@@ -18,6 +18,7 @@ import { ProjectEnvironments } from "../../features/project-environments/Project
 import { ParameterShareDialog } from "../../features/project-param-share/ParameterShareDialog";
 import { ProjectParamsTab } from "../../features/project-params/ProjectParamsTab";
 import { ProjectReleases } from "../../features/project-releases/ProjectReleases";
+import { ReleaseVersionDialog } from "../../features/project-releases/ReleaseVersionDialog";
 import { ProjectShareLinks } from "../../features/project-share-links/ProjectShareLinks";
 import { ProjectApiKeys } from "./components/ProjectApiKeys";
 import { ProjectPageSkeleton } from "./components/ProjectPageSkeleton";
@@ -75,8 +76,15 @@ export function ProjectReleasesPage() {
 
 function ProjectPageContent(props: { section: ProjectPageSection }) {
   const params = useParams<{ slug: string }>();
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
   const queryClient = useQueryClient();
   const { addToast } = useToast();
+
+  const releaseDraftVersion = () =>
+    typeof searchParams.release === "string" ? searchParams.release : undefined;
+  const viewedReleaseVersion = () =>
+    typeof searchParams.viewRelease === "string" ? searchParams.viewRelease : undefined;
 
   const [paramSearch, setParamSearch] = createSignal("");
   const [copiedKey, setCopiedKey] = createSignal<string | null>(null);
@@ -99,10 +107,12 @@ function ProjectPageContent(props: { section: ProjectPageSection }) {
   const [editDescription, setEditDescription] = createSignal("");
   const [showBulkImport, setShowBulkImport] = createSignal(false);
   const [deletingApiKeyId, setDeletingApiKeyId] = createSignal<string | null>(null);
-  const [confirmDraftRelease, setConfirmDraftRelease] = createSignal<string | null>(null);
-  const [draftingReleaseVersion, setDraftingReleaseVersion] = createSignal<string | null>(null);
   const [confirmDeleteRelease, setConfirmDeleteRelease] = createSignal<string | null>(null);
+  const [confirmActivateRelease, setConfirmActivateRelease] = createSignal<string | null>(null);
+  const [confirmClearActiveRelease, setConfirmClearActiveRelease] = createSignal(false);
   const [deletingReleaseVersion, setDeletingReleaseVersion] = createSignal<string | null>(null);
+  const [amendingReleaseVersion, setAmendingReleaseVersion] = createSignal<string | null>(null);
+  const [createVersionOpen, setCreateVersionOpen] = createSignal(false);
 
   createTimer(
     () => setCopiedKey(null),
@@ -115,6 +125,7 @@ function ProjectPageContent(props: { section: ProjectPageSection }) {
   const isSharedLinksPage = () => props.section === "sharedLinks";
   const isApiKeysPage = () => props.section === "apiKeys";
   const isReleasesPage = () => props.section === "releases";
+  const isViewingReleaseSnapshot = () => isParametersPage() && !!viewedReleaseVersion();
 
   const projectsQuery = useQuery(() => ({
     queryKey: projectKeys.list(),
@@ -167,13 +178,25 @@ function ProjectPageContent(props: { section: ProjectPageSection }) {
   const configQuery = useQuery(() => ({
     queryKey: projectKeys.configEntries(params.slug, activeEnvName()),
     queryFn: () => configEntryService.getAll(projectId(), activeEnvName()),
-    enabled: !!project() && !!activeEnvName() && isParametersPage()
+    enabled: !!project() && !!activeEnvName() && isParametersPage() && !isViewingReleaseSnapshot()
   }));
 
   const releasesQuery = useQuery(() => ({
     queryKey: projectKeys.configReleases(params.slug, activeEnvName()),
     queryFn: () => configReleaseService.getAll(projectId(), activeEnvName()),
     enabled: !!project() && !!activeEnvName() && isReleasesPage()
+  }));
+
+  const releaseDetailsQuery = useQuery(() => ({
+    queryKey: projectKeys.configReleaseDetails(
+      params.slug,
+      activeEnvName(),
+      viewedReleaseVersion() ?? ""
+    ),
+    queryFn: () =>
+      configReleaseService.get(projectId(), activeEnvName(), viewedReleaseVersion() ?? ""),
+    enabled: !!project() && !!activeEnvName() && isViewingReleaseSnapshot(),
+    staleTime: 60_000
   }));
 
   const sharedLinksQuery = useQuery(() => ({
@@ -207,14 +230,24 @@ function ProjectPageContent(props: { section: ProjectPageSection }) {
   const configHistoryQuery = useQuery(() => ({
     queryKey: projectKeys.configEntryHistory(params.slug, activeEnvName(), editHistoryQueryKey()),
     queryFn: () => configEntryService.history(projectId(), activeEnvName(), editHistoryQueryKey()),
-    enabled: !!project() && !!activeEnvName() && !!editHistoryQueryKey() && isParametersPage(),
+    enabled:
+      !!project() &&
+      !!activeEnvName() &&
+      !!editHistoryQueryKey() &&
+      isParametersPage() &&
+      !isViewingReleaseSnapshot(),
     staleTime: 60_000
   }));
 
   const shareLinksQuery = useQuery(() => ({
     queryKey: projectKeys.configEntryShareLinks(params.slug, activeEnvName(), shareLinksQueryKey()),
     queryFn: () => configEntryService.listShareLinks(projectId(), activeEnvName(), shareLinksQueryKey()),
-    enabled: !!project() && !!activeEnvName() && !!shareLinksQueryKey() && isParametersPage(),
+    enabled:
+      !!project() &&
+      !!activeEnvName() &&
+      !!shareLinksQueryKey() &&
+      isParametersPage() &&
+      !isViewingReleaseSnapshot(),
     staleTime: 60_000
   }));
 
@@ -223,6 +256,43 @@ function ProjectPageContent(props: { section: ProjectPageSection }) {
     queryFn: () => userService.getAll(),
     enabled: !!project()
   }));
+
+  const normalizeContentType = (
+    contentType: string
+  ): ConfigEntry["contentType"] =>
+    contentType === "number" ||
+    contentType === "boolean" ||
+    contentType === "json" ||
+    contentType === "text"
+      ? contentType
+      : "text";
+
+  const normalizeScope = (scope: string): ConfigEntry["scope"] =>
+    scope === "client" || scope === "server" || scope === "all" ? scope : "all";
+
+  const parameterEntries = createMemo<ConfigEntry[]>(() => {
+    if (isViewingReleaseSnapshot()) {
+      const release = releaseDetailsQuery.status === "success" ? releaseDetailsQuery.data : undefined;
+
+      return (release?.entries ?? []).map(entry => ({
+        project: release?.project ?? projectId(),
+        environment: release?.environment ?? activeEnvName(),
+        key: entry.key,
+        value: entry.value,
+        contentType: normalizeContentType(entry.contentType),
+        scope: normalizeScope(entry.scope),
+        activeVersion: 1,
+        createdAt: release?.createdAt ?? "",
+        updatedAt: release?.createdAt ?? ""
+      }));
+    }
+
+    return configQuery.status === "success" ? (configQuery.data ?? []) : [];
+  });
+
+  const parametersLoading = createMemo(() =>
+    isViewingReleaseSnapshot() ? releaseDetailsQuery.isLoading : configQuery.isLoading
+  );
 
   const canManageProject = createMemo(() =>
     canManageProjectResources(projectId(), usersQuery.status === "success" ? (usersQuery.data ?? []) : [])
@@ -236,7 +306,7 @@ function ProjectPageContent(props: { section: ProjectPageSection }) {
 
   const filteredConfig = createMemo(() => {
     const q = paramSearch().toLowerCase().trim();
-    const data = configQuery.status === "success" ? (configQuery.data ?? []) : [];
+    const data = parameterEntries();
     if (!q) return data;
     return data.filter(
       (e: ConfigEntry) =>
@@ -293,6 +363,7 @@ function ProjectPageContent(props: { section: ProjectPageSection }) {
       : false;
     const shouldAutoOpen =
       isParametersPage() &&
+      !isViewingReleaseSnapshot() &&
       configQuery.status === "success" &&
       canManageProject() &&
       !!environmentKey &&
@@ -331,6 +402,9 @@ function ProjectPageContent(props: { section: ProjectPageSection }) {
     setGeneratedShareUrl(null);
     setConfirmDeleteEntry(null);
     setEditDescription("");
+    setConfirmDeleteRelease(null);
+    setConfirmActivateRelease(null);
+    setConfirmClearActiveRelease(false);
   });
 
   const copyValue = async (key: string, value: string) => {
@@ -366,6 +440,10 @@ function ProjectPageContent(props: { section: ProjectPageSection }) {
     setShowEnvForm(false);
     setShowApiKeyForm(false);
     setShowBulkImport(false);
+    setCreateVersionOpen(false);
+    setConfirmDeleteRelease(null);
+    setConfirmActivateRelease(null);
+    setConfirmClearActiveRelease(false);
   });
 
   // Env creation mutation
@@ -399,9 +477,44 @@ function ProjectPageContent(props: { section: ProjectPageSection }) {
       });
       queryClient.invalidateQueries({ queryKey: projectKeys.environments(params.slug) });
       addToast(MSG.RELEASE_PUBLISHED, "success");
+      navigate(`/projects/${params.slug}/releases`);
     },
     onError: error => addToast(errorMessage(error, MSG.RELEASE_PUBLISH_FAILED), "error")
   }));
+
+  const amendReleaseMutation = useMutation(() => ({
+    mutationFn: (data: { source: string; target: string }) => {
+      setAmendingReleaseVersion(data.source);
+      return configReleaseService.createDraft(projectId(), activeEnvName(), data.source);
+    },
+    onSuccess: (_entries, data) => {
+      queryClient.invalidateQueries({
+        queryKey: projectKeys.configEntries(params.slug, activeEnvName())
+      });
+      navigate(`/projects/${params.slug}?release=${encodeURIComponent(data.target)}`);
+    },
+    onError: error => addToast(errorMessage(error, MSG.RELEASE_AMEND_FAILED), "error"),
+    onSettled: () => setAmendingReleaseVersion(null)
+  }));
+
+  const releaseVersions = createMemo(() =>
+    (releasesQuery.status === "success" ? (releasesQuery.data ?? []) : []).map(
+      release => release.version
+    )
+  );
+
+  const nextPatchVersion = (source: string) => {
+    const [major, minor] = source.split(".");
+    let maxPatch = 0;
+    for (const version of releaseVersions()) {
+      const [vMajor, vMinor, vPatch] = version.split(".");
+      if (vMajor === major && vMinor === minor) {
+        const patch = Number(vPatch);
+        if (Number.isFinite(patch) && patch > maxPatch) maxPatch = patch;
+      }
+    }
+    return `${major}.${minor}.${maxPatch + 1}`;
+  };
 
   const setActiveReleaseMutation = useMutation(() => ({
     mutationFn: (version: string | null) =>
@@ -416,22 +529,6 @@ function ProjectPageContent(props: { section: ProjectPageSection }) {
       addToast(MSG.RELEASE_ACTIVATED, "success");
     },
     onError: error => addToast(errorMessage(error, MSG.RELEASE_ACTIVATE_FAILED), "error")
-  }));
-
-  const createReleaseDraftMutation = useMutation(() => ({
-    mutationFn: (version: string) => {
-      setDraftingReleaseVersion(version);
-      return configReleaseService.createDraft(projectId(), activeEnvName(), version);
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: projectKeys.configEntries(params.slug, activeEnvName())
-      });
-      setConfirmDraftRelease(null);
-      addToast(MSG.RELEASE_DRAFT_CREATED, "success");
-    },
-    onError: error => addToast(errorMessage(error, MSG.RELEASE_DRAFT_FAILED), "error"),
-    onSettled: () => setDraftingReleaseVersion(null)
   }));
 
   const deleteReleaseMutation = useMutation(() => ({
@@ -511,6 +608,10 @@ function ProjectPageContent(props: { section: ProjectPageSection }) {
     setEditHistoryQueryKey("");
     const meta = localParamMetadataService.getMeta(projectId(), activeEnvName(), entry.key);
     setEditDescription(meta.description);
+
+    if (isViewingReleaseSnapshot()) {
+      return;
+    }
 
     requestAnimationFrame(() => {
       if (editingEntry()?.key === entry.key) {
@@ -768,17 +869,22 @@ function ProjectPageContent(props: { section: ProjectPageSection }) {
                   activeReleaseVersion={activeEnvironment()?.activeReleaseVersion}
                   releases={releasesQuery.status === "success" ? (releasesQuery.data ?? []) : []}
                   isLoading={releasesQuery.isLoading}
-                  isPublishing={publishReleaseMutation.isPending}
                   isActivating={setActiveReleaseMutation.isPending}
-                  draftingVersion={draftingReleaseVersion()}
+                  amendingVersion={amendingReleaseVersion()}
                   deletingVersion={deletingReleaseVersion()}
                   canManage={canManageProject()}
-                  onPublish={(version, makeActive) =>
-                    publishReleaseMutation.mutateAsync({ version, makeActive })
+                  onCreateVersion={() => setCreateVersionOpen(true)}
+                  onView={version =>
+                    navigate(`/projects/${params.slug}?viewRelease=${encodeURIComponent(version)}`)
                   }
-                  onActivate={version => setActiveReleaseMutation.mutate(version)}
-                  onClearActive={() => setActiveReleaseMutation.mutate(null)}
-                  onDraft={setConfirmDraftRelease}
+                  onAmend={version =>
+                    amendReleaseMutation.mutate({
+                      source: version,
+                      target: nextPatchVersion(version)
+                    })
+                  }
+                  onActivate={setConfirmActivateRelease}
+                  onClearActive={() => setConfirmClearActiveRelease(true)}
                   onDelete={setConfirmDeleteRelease}
                 />
               </Show>
@@ -807,15 +913,96 @@ function ProjectPageContent(props: { section: ProjectPageSection }) {
             </Show>
 
             <Show when={isParametersPage()}>
+              <Show when={isViewingReleaseSnapshot()}>
+                <div
+                  data-testid="release-view-banner"
+                  class="border-secondary/25 bg-secondary/5 animate-fade-in flex flex-col gap-3 rounded-2xl border p-4 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div class="flex items-center gap-2 text-[13px]">
+                    <span class="material-symbols-outlined text-secondary text-[18px]">
+                      visibility
+                    </span>
+                    <span class="text-on-surface-variant">
+                      Viewing release{" "}
+                      <span class="text-secondary font-mono font-bold">{viewedReleaseVersion()}</span>
+                      {" "}for {activeEnvName()}.
+                    </span>
+                  </div>
+                  <div class="flex flex-wrap justify-end gap-2">
+                    <button
+                      data-testid="release-view-back-to-releases-button"
+                      type="button"
+                      onClick={() => navigate(`/projects/${params.slug}/releases`)}
+                      class="bg-surface-container-high text-on-surface hover:bg-surface-bright inline-flex h-9 cursor-pointer items-center gap-1.5 rounded-lg border-0 px-4 text-[12px] font-semibold"
+                    >
+                      <span class="material-symbols-outlined text-[16px]">arrow_back</span>
+                      Back to releases
+                    </button>
+                    <button
+                      data-testid="release-view-back-button"
+                      type="button"
+                      onClick={() => navigate(`/projects/${params.slug}`)}
+                      class="border-outline-variant/30 bg-surface-container-low text-on-surface-variant hover:bg-surface-container inline-flex h-9 cursor-pointer items-center gap-1.5 rounded-lg border px-4 text-[12px] font-semibold"
+                    >
+                      <span class="material-symbols-outlined text-[16px]">tune</span>
+                      Live parameters
+                    </button>
+                  </div>
+                </div>
+              </Show>
+              <Show when={canManageProject() && releaseDraftVersion()}>
+                <div
+                  data-testid="release-draft-banner"
+                  class="border-primary/25 bg-primary/5 animate-fade-in flex flex-col gap-3 rounded-2xl border p-4 sm:flex-row sm:items-center sm:justify-between"
+                >
+                  <div class="flex items-center gap-2 text-[13px]">
+                    <span class="material-symbols-outlined text-primary text-[18px]">
+                      deployed_code_history
+                    </span>
+                    <span class="text-on-surface-variant">
+                      Composing release{" "}
+                      <span class="text-primary font-mono font-bold">{releaseDraftVersion()}</span> —
+                      adjust the parameters below, then create it.
+                    </span>
+                  </div>
+                  <div class="flex shrink-0 flex-wrap justify-end gap-2">
+                    <button
+                      data-testid="release-create-confirm-button"
+                      type="button"
+                      disabled={publishReleaseMutation.isPending || !activeEnvName()}
+                      onClick={() =>
+                        publishReleaseMutation.mutate({
+                          version: releaseDraftVersion()!,
+                          makeActive: false
+                        })
+                      }
+                      class="bg-primary text-on-primary inline-flex h-9 cursor-pointer items-center gap-1.5 rounded-lg border-0 px-4 text-[12px] font-semibold transition-all hover:brightness-105 active:scale-[0.98] disabled:opacity-50"
+                    >
+                      <span class="material-symbols-outlined text-[16px]">check</span>
+                      {publishReleaseMutation.isPending ? "Creating…" : "Create release"}
+                    </button>
+                    <button
+                      data-testid="release-create-cancel-button"
+                      type="button"
+                      disabled={publishReleaseMutation.isPending}
+                      onClick={() => navigate(`/projects/${params.slug}/releases`)}
+                      class="border-outline-variant/30 bg-surface-container-low text-on-surface-variant hover:bg-surface-container inline-flex h-9 cursor-pointer items-center gap-1.5 rounded-lg border px-4 text-[12px] font-semibold transition-all disabled:opacity-50"
+                    >
+                      <span class="material-symbols-outlined text-[16px]">close</span>
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              </Show>
               <ProjectParamsTab
                 activeEnvName={activeEnvName()}
                 environments={
                   environmentsQuery.status === "success" ? (environmentsQuery.data ?? []) : []
                 }
-                configEntries={configQuery.status === "success" ? (configQuery.data ?? []) : []}
+                configEntries={parameterEntries()}
                 filteredConfig={filteredConfig()}
                 editingEntry={editingEntry()}
-                isLoading={configQuery.isLoading}
+                isLoading={parametersLoading()}
                 projectId={projectId()}
                 paramSearch={paramSearch()}
                 onParamSearch={setParamSearch}
@@ -829,11 +1016,11 @@ function ProjectPageContent(props: { section: ProjectPageSection }) {
                 }}
                 showConfigForm={showConfigForm()}
                 bulkImportPanel={
-                  canManageProject() && showBulkImport() ? (
+                  !isViewingReleaseSnapshot() && canManageProject() && showBulkImport() ? (
                     <ProjectBulkImport
                       onCancel={() => setShowBulkImport(false)}
                       onImport={handleBulkImport}
-                      existingEntries={configQuery.status === "success" ? (configQuery.data ?? []) : []}
+                      existingEntries={parameterEntries()}
                       isPending={updateConfigMutation.isPending}
                       addToast={addToast}
                     />
@@ -857,7 +1044,7 @@ function ProjectPageContent(props: { section: ProjectPageSection }) {
                 onSelectEntry={handleOpenEditDrawer}
                 onShareEntry={handleOpenShareDialog}
                 onDeleteEntry={setConfirmDeleteEntry}
-                canManage={canManageProject()}
+                canManage={canManageProject() && !isViewingReleaseSnapshot()}
                 copiedKey={copiedKey()}
                 onCopyValue={copyValue}
                 getParamMeta={(proj, env, key) => localParamMetadataService.getMeta(proj, env, key)}
@@ -882,6 +1069,8 @@ function ProjectPageContent(props: { section: ProjectPageSection }) {
                 isHistoryLoading={configHistoryQuery.isLoading}
                 isRollingBack={rollbackConfigMutation.isPending}
                 onRollbackVersion={handleRollbackVersion}
+                isReadOnly={isViewingReleaseSnapshot()}
+                viewingReleaseVersion={viewedReleaseVersion()}
               />
 
               <ParameterShareDialog
@@ -965,29 +1154,51 @@ function ProjectPageContent(props: { section: ProjectPageSection }) {
 
       <Show when={isReleasesPage()}>
         <ConfirmDialog
-          open={confirmDraftRelease() !== null}
-          title="Load Release into Workspace?"
+          open={confirmActivateRelease() !== null}
+          title="Activate Release?"
           message={
             <>
-              Load release <span class="text-primary font-mono font-bold">{confirmDraftRelease()}</span>{" "}
-              into the editable working configuration for{" "}
-              <span class="text-on-surface font-medium">{activeEnvName()}</span>? This replaces any
-              unpublished changes, but does not change the active release or what clients receive.
+              Make release{" "}
+              <span class="text-primary font-mono font-bold">{confirmActivateRelease()}</span> the
+              active version for the{" "}
+              <span class="text-on-surface font-medium">{activeEnvName()}</span> environment?
             </>
           }
-          confirmLabel="Load Release"
-          variant="info"
-          isLoading={createReleaseDraftMutation.isPending}
+          confirmLabel="Activate Release"
+          isLoading={setActiveReleaseMutation.isPending}
           onConfirm={() => {
-            const version = confirmDraftRelease();
+            const version = confirmActivateRelease();
             if (version) {
-              createReleaseDraftMutation.mutate(version);
+              setActiveReleaseMutation.mutate(version);
+              setConfirmActivateRelease(null);
             }
           }}
-          onCancel={() => setConfirmDraftRelease(null)}
-          testId="release-draft-dialog"
-          confirmTestId="release-draft-confirm-button"
-          cancelTestId="release-draft-cancel-button"
+          onCancel={() => setConfirmActivateRelease(null)}
+          testId="release-activate-dialog"
+          confirmTestId="release-activate-confirm-button"
+          cancelTestId="release-activate-cancel-button"
+        />
+
+        <ConfirmDialog
+          open={confirmClearActiveRelease()}
+          title="Clear Active Release?"
+          message={
+            <>
+              Remove the active release from the{" "}
+              <span class="text-on-surface font-medium">{activeEnvName()}</span> environment? Clients
+              will no longer resolve to a pinned release until another one is activated.
+            </>
+          }
+          confirmLabel="Clear Active Release"
+          isLoading={setActiveReleaseMutation.isPending}
+          onConfirm={() => {
+            setActiveReleaseMutation.mutate(null);
+            setConfirmClearActiveRelease(false);
+          }}
+          onCancel={() => setConfirmClearActiveRelease(false)}
+          testId="release-clear-active-dialog"
+          confirmTestId="release-clear-active-confirm-button"
+          cancelTestId="release-clear-active-cancel-button"
         />
 
         <ConfirmDialog
@@ -1014,6 +1225,24 @@ function ProjectPageContent(props: { section: ProjectPageSection }) {
           testId="release-delete-dialog"
           confirmTestId="release-delete-confirm-button"
           cancelTestId="release-delete-cancel-button"
+        />
+
+        <ReleaseVersionDialog
+          open={createVersionOpen()}
+          title="Create a version"
+          description="Choose a major and minor version. The release will start at patch .0 after you review its parameters."
+          initialVersion=""
+          existingVersions={releaseVersions()}
+          confirmLabel="Continue to parameters"
+          placeholder="1.2"
+          validationMessage="Use major.minor."
+          versionFormat="majorMinor"
+          normalizeVersion={version => `${version}.0`}
+          onConfirm={version => {
+            setCreateVersionOpen(false);
+            navigate(`/projects/${params.slug}?release=${encodeURIComponent(version)}`);
+          }}
+          onCancel={() => setCreateVersionOpen(false)}
         />
       </Show>
     </>

--- a/admin/src/pages/projects/ProjectsPage.tsx
+++ b/admin/src/pages/projects/ProjectsPage.tsx
@@ -139,7 +139,7 @@ export default function ProjectsPage() {
               </div>
             </div>
 
-            <div class="flex flex-col gap-2 md:w-auto md:flex-row md:flex-wrap md:items-center md:justify-end">
+            <div class="flex w-full min-w-0 items-center justify-end gap-2 md:w-auto md:flex-row md:flex-wrap md:items-center md:justify-end">
               <Show when={projectsQuery.isSuccess && allProjects().length > 0}>
                 <Input
                   data-testid="projects-search-input"
@@ -149,19 +149,21 @@ export default function ProjectsPage() {
                   onInput={(e: InputEvent & { currentTarget: HTMLInputElement }) =>
                     setSearch(e.currentTarget.value)
                   }
-                  class="h-10 w-full md:w-64"
+                  class="h-10 min-w-0 flex-1 md:w-64"
                   leftIcon="search"
-                  wrapperStyle="w-full md:w-auto"
+                  wrapperStyle="min-w-0 flex-1 md:w-auto md:flex-none"
                 />
               </Show>
               <Show when={allowProjectManagement()}>
                 <button
                   data-testid="projects-new-button"
                   onClick={() => setShowCreate(!showCreate())}
-                  class="bg-primary text-on-primary flex shrink-0 cursor-pointer items-center gap-2 rounded-lg border-0 px-4 py-2 text-[13px] font-semibold transition-all hover:brightness-105 active:scale-[0.98]"
+                  aria-label={showCreate() ? "Cancel new project" : "New Project"}
+                  title={showCreate() ? "Cancel new project" : "New Project"}
+                  class="bg-primary text-on-primary inline-flex h-10 w-10 shrink-0 self-end cursor-pointer items-center justify-center gap-2 rounded-lg border-0 px-0 text-[13px] font-semibold transition-all hover:brightness-105 active:scale-[0.98] md:h-10 md:w-auto md:px-4 md:self-auto"
                 >
                   <MIcon name={showCreate() ? "close" : "add"} class="text-[17px]" />
-                  {showCreate() ? "Cancel" : "New Project"}
+                  <span class="hidden md:inline">{showCreate() ? "Cancel" : "New Project"}</span>
                 </button>
               </Show>
             </div>

--- a/admin/src/pages/projects/components/ProjectApiKeys.tsx
+++ b/admin/src/pages/projects/components/ProjectApiKeys.tsx
@@ -96,10 +96,12 @@ export function ProjectApiKeys(props: ProjectApiKeysProps) {
             data-testid="project-add-api-key-button"
             type="button"
             onClick={() => props.setShowCreateForm(!props.showCreateForm)}
-            class="bg-primary text-on-primary inline-flex h-10 cursor-pointer items-center gap-1.5 self-start rounded-lg border-0 px-4 text-[13px] font-semibold transition-all hover:brightness-105 active:scale-[0.98] md:self-auto"
+            aria-label="Add API Key"
+            title="Add API Key"
+            class="bg-primary text-on-primary inline-flex h-10 w-10 cursor-pointer items-center justify-center gap-1.5 self-end rounded-lg border-0 px-0 text-[13px] font-semibold transition-all hover:brightness-105 active:scale-[0.98] md:h-10 md:w-auto md:px-4 md:self-auto"
           >
             <MIcon name="add" class="text-[16px]" />
-            Add API Key
+            <span class="hidden md:inline">Add API Key</span>
           </button>
         </Show>
       </div>

--- a/admin/src/pages/projects/components/ProjectGrid.tsx
+++ b/admin/src/pages/projects/components/ProjectGrid.tsx
@@ -58,10 +58,12 @@ export function ProjectGrid(props: ProjectGridProps) {
                 <button
                   data-testid="empty-projects-new-button"
                   onClick={() => props.onCreateClick()}
-                  class="bg-primary text-on-primary inline-flex cursor-pointer items-center gap-1.5 rounded-lg border-0 px-4 py-2 text-[13px] font-semibold transition-all hover:brightness-105"
+                  aria-label="New Project"
+                  title="New Project"
+                  class="bg-primary text-on-primary inline-flex h-10 w-10 cursor-pointer items-center justify-center gap-1.5 rounded-lg border-0 px-0 text-[13px] font-semibold transition-all hover:brightness-105 md:h-auto md:w-auto md:px-4 md:py-2"
                 >
                   <MIcon name="add" class="text-[17px]" />
-                  New Project
+                  <span class="hidden md:inline">New Project</span>
                 </button>
               </Show>
             </div>
@@ -148,9 +150,11 @@ export function ProjectGrid(props: ProjectGridProps) {
                 data-testid="project-grid-new-button"
                 onClick={() => props.onCreateClick()}
                 class="border-outline-variant/40 text-outline hover:border-primary/30 hover:text-primary hover:bg-primary/5 flex min-h-37 cursor-pointer flex-col items-center justify-center gap-2 rounded-2xl border border-dashed bg-transparent p-5 transition-all"
+                aria-label="New Project"
+                title="New Project"
               >
                 <MIcon name="add" class="text-2xl" />
-                <span class="text-[12.5px] font-medium">New Project</span>
+                <span class="hidden md:inline text-[12.5px] font-medium">New Project</span>
               </button>
             </Show>
           </div>

--- a/admin/src/pages/users/UsersPage.tsx
+++ b/admin/src/pages/users/UsersPage.tsx
@@ -16,6 +16,7 @@ import { userKeys } from "../../entities/user/queries/keys";
 import { MSG } from "../../shared/lib/messages";
 import { ConfirmDialog } from "../../shared/ui/confirm-dialog";
 import { MIcon } from "../../shared/ui/icons";
+import { Input } from "../../shared/ui/input";
 import { QueryErrorBanner } from "../../shared/ui/QueryGuard";
 import { useToast } from "../../shared/ui/toast";
 import type { CreateUserResponse, User } from "../../types";
@@ -201,16 +202,34 @@ export default function UsersPage() {
                 />
               </div>
             </div>
-            <Show when={allowUserManagement()}>
-              <button
-                data-testid="team-invite-button"
-                onClick={toggleInvite}
-                class="bg-primary text-on-primary flex shrink-0 cursor-pointer items-center gap-2 rounded-lg border-0 px-4 py-2 text-[13px] font-semibold transition-all hover:brightness-105 active:scale-[0.98]"
-              >
-                <MIcon name={showInvite() ? "close" : "person_add"} class="text-[17px]" />
-                {showInvite() ? "Cancel" : "Invite Member"}
-              </button>
-            </Show>
+            <div class="flex w-full min-w-0 items-center justify-end gap-2 md:w-auto md:flex-row md:flex-wrap md:items-center md:justify-end">
+              <Input
+                data-testid="team-search-input"
+                type="text"
+                placeholder="Search by name or email..."
+                value={search()}
+                onInput={(e: InputEvent & { currentTarget: HTMLInputElement }) =>
+                  setSearch(e.currentTarget.value)
+                }
+                class="h-10 min-w-0 flex-1 md:w-72"
+                leftIcon="search"
+                wrapperStyle="min-w-0 flex-1 md:w-auto md:flex-none"
+              />
+              <Show when={allowUserManagement()}>
+                <button
+                  data-testid="team-invite-button"
+                  onClick={toggleInvite}
+                  aria-label={showInvite() ? "Cancel invite" : "Invite Member"}
+                  title={showInvite() ? "Cancel invite" : "Invite Member"}
+                  class="bg-primary text-on-primary inline-flex h-10 w-10 shrink-0 cursor-pointer items-center justify-center gap-2 rounded-lg border-0 px-0 text-[13px] font-semibold transition-all hover:brightness-105 active:scale-[0.98] md:h-10 md:w-auto md:px-4"
+                >
+                  <MIcon name={showInvite() ? "close" : "person_add"} class="text-[17px]" />
+                  <span class="hidden md:inline">
+                    {showInvite() ? "Cancel" : "Invite Member"}
+                  </span>
+                </button>
+              </Show>
+            </div>
           </div>
 
           {/* Error banner */}
@@ -227,6 +246,7 @@ export default function UsersPage() {
             roleFilter={roleFilter()}
             onSearchChange={setSearch}
             onRoleFilterChange={setRoleFilter}
+            hideSearch
           />
 
           {/* Inline invite form */}

--- a/admin/src/pages/users/components/UserIdentityForm.tsx
+++ b/admin/src/pages/users/components/UserIdentityForm.tsx
@@ -12,7 +12,7 @@ interface UserIdentityFormProps {
 
 export function UserIdentityForm(props: UserIdentityFormProps) {
   return (
-    <section class="bg-surface-container-low border-outline-variant/15 space-y-6 rounded-xl border p-8">
+    <section class="bg-surface-container-low border-outline-variant/15 space-y-5 rounded-xl border p-4 sm:p-8">
       <div class="flex items-center gap-3">
         <div class="bg-primary/10 border-primary/20 text-primary flex h-7 w-7 shrink-0 items-center justify-center rounded-full border font-mono text-xs font-bold shadow-[0_0_12px_rgba(99,102,241,0.15)]">
           01
@@ -21,7 +21,7 @@ export function UserIdentityForm(props: UserIdentityFormProps) {
           {props.isEditMode ? "Member Identity" : "Invitee Identity"}
         </h3>
       </div>
-      <div class="grid grid-cols-1 gap-6 md:grid-cols-2">
+      <div class="grid grid-cols-1 gap-4 md:grid-cols-2 md:gap-6">
         <div class="space-y-2">
           <Label for="user-full-name" class="mb-0">
             Full Name or Alias

--- a/admin/src/pages/users/components/UserProjectScope.tsx
+++ b/admin/src/pages/users/components/UserProjectScope.tsx
@@ -9,7 +9,7 @@ interface UserProjectScopeProps {
 
 export function UserProjectScope(props: UserProjectScopeProps) {
   return (
-    <section class="bg-surface-container-low border-outline-variant/15 space-y-6 rounded-xl border p-8 shadow-sm">
+    <section class="bg-surface-container-low border-outline-variant/15 space-y-5 rounded-xl border p-4 shadow-sm sm:p-8">
       <div class="flex items-center gap-3">
         <div class="bg-primary/10 border-primary/20 text-primary flex h-7 w-7 shrink-0 items-center justify-center rounded-full border font-mono text-xs font-bold shadow-[0_0_12px_rgba(99,102,241,0.15)]">
           03
@@ -17,7 +17,7 @@ export function UserProjectScope(props: UserProjectScopeProps) {
         <h3 class="font-headline text-on-surface text-lg font-bold">Project Scope</h3>
       </div>
       <div class="bg-surface-container-low border-outline-variant/15 overflow-hidden rounded-xl border">
-        <div class="bg-surface-container-low border-outline-variant/15 text-outline grid grid-cols-2 border-b px-6 py-3.5 text-[10px] font-bold tracking-widest uppercase">
+        <div class="bg-surface-container-low border-outline-variant/15 text-outline hidden grid-cols-2 border-b px-6 py-3.5 text-[10px] font-bold tracking-widest uppercase sm:grid">
           <span>Active Projects</span>
           <span class="text-right">Access Level</span>
         </div>
@@ -32,7 +32,7 @@ export function UserProjectScope(props: UserProjectScopeProps) {
               return (
                 <div
                   data-testid={`invite-project-row-${project.urlSlug}`}
-                  class="hover:bg-surface-container-high/40 border-outline-variant/10 grid cursor-pointer grid-cols-2 items-center border-b px-6 py-4 transition-colors last:border-b-0"
+                  class="hover:bg-surface-container-high/40 border-outline-variant/10 grid cursor-pointer gap-3 border-b px-4 py-4 transition-colors last:border-b-0 sm:grid-cols-2 sm:items-center sm:px-6"
                   onClick={() => props.onToggleProject(projectName)}
                 >
                   <div class="flex items-center gap-3">
@@ -49,7 +49,7 @@ export function UserProjectScope(props: UserProjectScopeProps) {
                       {project.urlSlug}
                     </span>
                   </div>
-                  <div class="text-right">
+                  <div class="sm:text-right">
                     <Show
                       when={isGiven()}
                       fallback={

--- a/admin/src/pages/users/components/UserRoleSelector.tsx
+++ b/admin/src/pages/users/components/UserRoleSelector.tsx
@@ -22,7 +22,7 @@ export function UserRoleSelector(props: UserRoleSelectorProps) {
   ];
 
   return (
-    <section class="bg-surface-container-low border-outline-variant/15 space-y-6 rounded-xl border p-8 shadow-sm">
+    <section class="bg-surface-container-low border-outline-variant/15 space-y-5 rounded-xl border p-4 shadow-sm sm:p-8">
       <div class="flex items-center gap-3">
         <div class="bg-primary/10 border-primary/20 text-primary flex h-7 w-7 shrink-0 items-center justify-center rounded-full border font-mono text-xs font-bold shadow-[0_0_12px_rgba(99,102,241,0.15)]">
           02
@@ -32,7 +32,7 @@ export function UserRoleSelector(props: UserRoleSelectorProps) {
       <div
         role="radiogroup"
         aria-label="System Role Assignment"
-        class="grid grid-cols-1 gap-4 md:grid-cols-2"
+        class="grid grid-cols-1 gap-3 md:grid-cols-2 md:gap-4"
       >
         <For each={ROLE_CARDS}>
           {card => {
@@ -50,7 +50,7 @@ export function UserRoleSelector(props: UserRoleSelectorProps) {
                     props.onChange(card.value);
                   }
                 }}
-                class={`focus-visible:ring-primary/40 h-full cursor-pointer rounded-lg border p-6 transition-all duration-300 select-none focus-visible:ring-2 focus-visible:outline-none active:scale-[0.98] ${
+                class={`focus-visible:ring-primary/40 h-full cursor-pointer rounded-lg border p-4 transition-all duration-300 select-none focus-visible:ring-2 focus-visible:outline-none active:scale-[0.98] sm:p-6 ${
                   isSelected()
                     ? "border-primary bg-primary/5 scale-[1.01] shadow-[0_0_20px_rgba(99,102,241,0.03)]"
                     : "bg-surface-container-low border-outline-variant/15 hover:bg-surface-container-high/40 hover:border-outline-variant/30"

--- a/admin/src/pages/users/components/UsersFilters.tsx
+++ b/admin/src/pages/users/components/UsersFilters.tsx
@@ -1,3 +1,4 @@
+import { Show } from "solid-js";
 import { Input } from "../../../shared/ui/input";
 import { Select } from "../../../shared/ui/select";
 
@@ -6,24 +7,27 @@ interface UsersFiltersProps {
   roleFilter: string;
   onSearchChange: (val: string) => void;
   onRoleFilterChange: (val: string) => void;
+  hideSearch?: boolean;
 }
 
 export function UsersFilters(props: UsersFiltersProps) {
   return (
     <div class="flex flex-col gap-3 sm:flex-row">
-      <div class="max-w-sm flex-1">
-        <Input
-          data-testid="team-search-input"
-          type="text"
-          placeholder="Search by name or email…"
-          value={props.search}
-          onInput={(e: InputEvent & { currentTarget: HTMLInputElement }) =>
-            props.onSearchChange(e.currentTarget.value)
-          }
-          class="h-10"
-          leftIcon="search"
-        />
-      </div>
+      <Show when={!props.hideSearch}>
+        <div class="max-w-sm flex-1">
+          <Input
+            data-testid="team-search-input"
+            type="text"
+            placeholder="Search by name or email..."
+            value={props.search}
+            onInput={(e: InputEvent & { currentTarget: HTMLInputElement }) =>
+              props.onSearchChange(e.currentTarget.value)
+            }
+            class="h-10"
+            leftIcon="search"
+          />
+        </div>
+      </Show>
       <div class="w-full sm:w-48">
         <Select
           value={props.roleFilter}

--- a/admin/src/pages/users/components/UsersTable.tsx
+++ b/admin/src/pages/users/components/UsersTable.tsx
@@ -1,4 +1,4 @@
-import { For, Show } from "solid-js";
+import { For, Show, createSignal, onCleanup, onMount } from "solid-js";
 import { MIcon } from "../../../shared/ui/icons";
 import type { Project, User } from "../../../types";
 import { UserForm, type UserFormValue } from "./UserForm";
@@ -43,9 +43,202 @@ function roleMeta(role: string) {
 }
 
 export function UsersTable(props: UsersTableProps) {
+  const [isMobile, setIsMobile] = createSignal(false);
+
+  onMount(() => {
+    const syncViewport = () => setIsMobile(window.innerWidth < 768);
+    syncViewport();
+    window.addEventListener("resize", syncViewport);
+    onCleanup(() => window.removeEventListener("resize", syncViewport));
+  });
+
   return (
-    <div class="bg-surface-container-low border-outline-variant/15 overflow-hidden rounded-xl border">
-      <div class="overflow-x-auto">
+    <div class="space-y-3">
+      <Show when={isMobile()}>
+        <div class="space-y-3">
+          <Show when={props.isLoading}>
+            <For each={[1, 2, 3]}>
+              {() => <div class="skeleton h-36 w-full rounded-2xl" />}
+            </For>
+          </Show>
+
+          <Show
+            when={!props.isLoading && props.filteredUsers.length === 0 && props.totalUsersCount === 0}
+          >
+            <div class="bg-surface-container-low border-outline-variant/15 animate-fade-in rounded-2xl border p-10 text-center">
+              <div class="bg-primary/5 mb-4 inline-flex h-14 w-14 items-center justify-center rounded-2xl">
+                <MIcon name="group_add" class="text-primary/60 text-3xl" />
+              </div>
+              <p class="text-on-surface font-headline mb-1 text-[14px] font-bold">
+                No team members yet
+              </p>
+              <p class="text-on-surface-variant mb-4 text-[13px]">
+                Invite your first team member to get started.
+              </p>
+              <Show when={props.onInvite}>
+                <button
+                  type="button"
+                  onClick={() => props.onInvite?.()}
+                  class="bg-primary text-on-primary inline-flex cursor-pointer items-center gap-2 rounded-lg border-0 px-4 py-2 text-[13px] font-semibold transition-all hover:brightness-105 active:scale-[0.98]"
+                >
+                  <MIcon name="person_add" class="text-[17px]" />
+                  Invite Member
+                </button>
+              </Show>
+            </div>
+          </Show>
+
+          <Show
+            when={!props.isLoading && props.filteredUsers.length === 0 && props.totalUsersCount > 0}
+          >
+            <div class="text-on-surface-variant py-10 text-center text-sm">
+              No members match your search
+            </div>
+          </Show>
+
+          <Show when={!props.isLoading}>
+            <For each={props.filteredUsers}>
+              {(user: User) => {
+                const initials = user.name
+                  ? user.name.slice(0, 2).toUpperCase()
+                  : user.email.slice(0, 2).toUpperCase();
+                const rm = roleMeta(user.role);
+                const isCurrentUser =
+                  props.currentUserEmail?.toLowerCase() === user.email.toLowerCase();
+                const canEditUser = props.canManageUsers || isCurrentUser;
+                const isExpanded = () => props.editingUserId === user.id;
+
+                return (
+                  <article class="bg-surface-container border-outline-variant/10 overflow-hidden rounded-2xl border">
+                    <div
+                      data-testid={`team-row-${user.id}`}
+                      role={canEditUser ? "button" : undefined}
+                      tabindex={canEditUser ? 0 : undefined}
+                      aria-label={canEditUser ? `Edit ${user.email}` : undefined}
+                      onClick={() => {
+                        if (canEditUser) props.onEdit(user);
+                      }}
+                      onKeyDown={e => {
+                        if (!canEditUser) return;
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          props.onEdit(user);
+                        }
+                      }}
+                      class={`p-4 ${canEditUser ? "cursor-pointer" : ""}`}
+                    >
+                      <div class="flex items-start gap-3">
+                        <Show when={canEditUser}>
+                          <div
+                            class={`bg-surface-container-high text-outline mt-1 flex h-7 w-7 shrink-0 items-center justify-center rounded-lg transition-transform ${
+                              isExpanded() ? "rotate-180" : ""
+                            }`}
+                          >
+                            <MIcon name="expand_more" class="text-[16px]" />
+                          </div>
+                        </Show>
+                        <div class="font-headline bg-primary/10 text-primary border-primary/20 flex h-9 w-9 shrink-0 items-center justify-center rounded-full border text-xs font-bold">
+                          {initials}
+                        </div>
+                        <div class="min-w-0 flex-1 space-y-3">
+                          <div class="min-w-0">
+                            <div class="font-headline text-on-surface text-sm font-semibold">
+                              {user.name || "Pending Invite"}
+                            </div>
+                            <div class="text-outline mt-0.5 break-all font-mono text-[11.5px]">
+                              {user.email}
+                            </div>
+                          </div>
+
+                          <div class="flex flex-wrap gap-2">
+                            <span
+                              class={`inline-flex items-center rounded-md px-2 py-0.5 text-[11px] font-medium ${rm.class}`}
+                            >
+                              {rm.label}
+                            </span>
+                            <span class="text-on-surface-variant inline-flex items-center gap-1.5 text-[12px]">
+                              <span class="material-symbols-outlined text-outline text-[16px]">
+                                {user.role === "admin" ? "public" : "lock_person"}
+                              </span>
+                              <span>
+                                {user.role === "admin" ? "Global Access" : "Scoped Access"}
+                              </span>
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+
+                    <Show when={props.canManageUsers}>
+                      <div class="border-outline-variant/10 flex justify-end border-t px-4 py-2">
+                        <button
+                          data-testid={`team-remove-${user.id}`}
+                          type="button"
+                          disabled={isCurrentUser}
+                          onClick={() => {
+                            if (!isCurrentUser) props.onDelete(user);
+                          }}
+                          class={
+                            isCurrentUser
+                              ? "text-outline/35 cursor-not-allowed rounded-lg border-0 bg-transparent p-1.5 opacity-60"
+                              : "text-outline hover:text-error hover:bg-error/10 cursor-pointer rounded-lg border-0 bg-transparent p-1.5"
+                          }
+                          title={
+                            isCurrentUser
+                              ? "You cannot remove your own account"
+                              : `Remove ${user.name || user.email}`
+                          }
+                          aria-label={
+                            isCurrentUser
+                              ? "You cannot remove your own account"
+                              : `Remove ${user.name || user.email}`
+                          }
+                        >
+                          <MIcon name="delete_outline" class="text-[18px]" />
+                        </button>
+                      </div>
+                    </Show>
+
+                    <Show when={isExpanded()}>
+                      <div
+                        data-testid={`team-edit-row-${user.id}`}
+                        class="bg-surface-container-lowest/30 border-outline-variant/10 border-t px-4 py-4"
+                      >
+                        <Show
+                          when={!props.isEditLoading && props.editingUser}
+                          fallback={<div class="skeleton h-48 w-full rounded-xl" />}
+                        >
+                          <UserForm
+                            mode="edit"
+                            initial={{
+                              name: props.editingUser!.name,
+                              email: props.editingUser!.email,
+                              role: props.editingUser!.role,
+                              isAdmin: props.editingUser!.isAdmin,
+                              projects: (props.editingUser!.projects ?? []).map(
+                                p => p.projectName
+                              )
+                            }}
+                            projects={props.projects}
+                            allowManagement={props.canManageUsers}
+                            isPending={props.isSaving}
+                            onCancel={props.onCancelEdit}
+                            onSubmit={props.onSubmitEdit}
+                          />
+                        </Show>
+                      </div>
+                    </Show>
+                  </article>
+                );
+              }}
+            </For>
+          </Show>
+        </div>
+      </Show>
+
+      <Show when={!isMobile()}>
+        <div class="bg-surface-container-low border-outline-variant/15 overflow-hidden rounded-xl border">
+          <div class="overflow-x-auto">
         <table class="w-full border-collapse text-left">
           <thead>
             <tr class="border-outline-variant/15 bg-surface-container-lowest/50 border-b">
@@ -267,7 +460,9 @@ export function UsersTable(props: UsersTableProps) {
             </Show>
           </tbody>
         </table>
-      </div>
+          </div>
+        </div>
+      </Show>
     </div>
   );
 }

--- a/admin/src/shared/lib/messages.ts
+++ b/admin/src/shared/lib/messages.ts
@@ -28,8 +28,7 @@ export const MSG = {
   RELEASE_PUBLISH_FAILED: "Failed to publish release",
   RELEASE_ACTIVATED: "Active release updated",
   RELEASE_ACTIVATE_FAILED: "Failed to update active release",
-  RELEASE_DRAFT_CREATED: "Working draft created",
-  RELEASE_DRAFT_FAILED: "Failed to create working draft",
+  RELEASE_AMEND_FAILED: "Failed to start amending the release",
   RELEASE_DELETED: "Release deleted",
   RELEASE_DELETE_FAILED: "Failed to delete release",
 

--- a/admin/src/widgets/app-shell/Header.tsx
+++ b/admin/src/widgets/app-shell/Header.tsx
@@ -85,120 +85,168 @@ export function Header(props: HeaderProps) {
     syncActiveEnvironment(project.urlSlug, environments());
   });
 
+  const projectOptions = createMemo(() => [
+    ...projects().map(project => ({
+      value: project.urlSlug,
+      label: project.name,
+    })),
+    ...(canCreateProjects
+      ? [{ value: MANAGE_PROJECTS_OPTION, label: "List or Create Projects" }]
+      : []),
+  ]);
+
+  const environmentOptions = createMemo(() => [
+    ...environments().map(environment => ({
+      value: environment.name,
+      label: environment.name,
+    })),
+    ...(activeProject()
+      ? [
+          {
+            value: MANAGE_ENVIRONMENTS_OPTION,
+            label: "List or Create Environments",
+          },
+        ]
+      : []),
+  ]);
+
+  const handleProjectChange = (slug: string) => {
+    if (slug === MANAGE_PROJECTS_OPTION) {
+      navigate("/projects");
+      return;
+    }
+
+    setActiveProjectSlug(slug);
+    navigate(getProjectNavigationPath(location.pathname, slug));
+  };
+
+  const handleEnvironmentChange = (environmentName: string) => {
+    const project = activeProject();
+    if (!project) {
+      return;
+    }
+
+    if (environmentName === MANAGE_ENVIRONMENTS_OPTION) {
+      navigate(`/projects/${project.urlSlug}/environments`);
+      return;
+    }
+
+    setActiveEnvironmentName(project.urlSlug, environmentName);
+  };
+
   return (
-    <header class="sticky top-0 z-40 w-full bg-background/80 backdrop-blur-md border-b border-outline-variant/15 flex items-center h-14 px-5 md:px-7 gap-3 shrink-0">
-      <button
-        onClick={() => props.onMenuToggle()}
-        class="lg:hidden p-2 -ml-1 text-on-surface-variant hover:text-on-surface bg-transparent border-0 cursor-pointer flex items-center justify-center rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
-        aria-label="Toggle navigation menu"
-      >
-        <span class="material-symbols-outlined text-2xl">
-          {props.isSidebarOpen ? "close" : "menu"}
-        </span>
-      </button>
-
-      <Breadcrumbs />
-
-      <div class="hidden flex-1 min-w-0 lg:flex lg:items-center lg:justify-end lg:gap-5">
-        <div class="flex min-w-0 max-w-[36rem] flex-[1.15] items-center gap-3">
-          <span class="shrink-0 text-[11px] font-semibold uppercase tracking-[0.08em] text-on-surface-variant">
-            Active Project
+    <header class="sticky top-0 z-40 w-full shrink-0 border-b border-outline-variant/15 bg-background/80 backdrop-blur-md">
+      <div class="flex min-h-14 items-center gap-3 px-5 md:px-7">
+        <button
+          onClick={() => props.onMenuToggle()}
+          class="lg:hidden -ml-1 flex items-center justify-center rounded-lg border-0 bg-transparent p-2 text-on-surface-variant cursor-pointer hover:text-on-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40"
+          aria-label="Toggle navigation menu"
+        >
+          <span class="material-symbols-outlined text-2xl">
+            {props.isSidebarOpen ? "close" : "menu"}
           </span>
-          <Select
-            value={getActiveProjectSlug()}
-            onChange={slug => {
-              if (slug === MANAGE_PROJECTS_OPTION) {
-                navigate("/projects");
-                return;
-              }
+        </button>
 
-              setActiveProjectSlug(slug);
-              navigate(getProjectNavigationPath(location.pathname, slug));
-            }}
-            options={[
-              ...projects().map(project => ({
-                value: project.urlSlug,
-                label: project.name,
-              })),
-              ...(canCreateProjects
-                ? [{ value: MANAGE_PROJECTS_OPTION, label: "List or Create Projects" }]
-                : []),
-            ]}
-            placeholder={projectsQuery.isLoading ? "Loading projects..." : "Select a project"}
-            disabled={projectsQuery.isLoading || (projects().length === 0 && !canCreateProjects)}
-            class="h-9 w-full min-w-0 rounded-xl border-outline-variant/20 bg-surface-container-low text-[12px]"
-          />
+        <Breadcrumbs />
+
+        <div class="hidden min-w-0 flex-1 lg:flex lg:items-center lg:justify-end lg:gap-5">
+          <div class="flex min-w-0 max-w-[36rem] flex-[1.15] items-center gap-3">
+            <span class="shrink-0 text-[11px] font-semibold uppercase tracking-[0.08em] text-on-surface-variant">
+              Active Project
+            </span>
+            <Select
+              value={getActiveProjectSlug()}
+              onChange={handleProjectChange}
+              options={projectOptions()}
+              placeholder={projectsQuery.isLoading ? "Loading projects..." : "Select a project"}
+              disabled={projectsQuery.isLoading || (projects().length === 0 && !canCreateProjects)}
+              class="h-9 w-full min-w-0 rounded-xl border-outline-variant/20 bg-surface-container-low text-[12px]"
+            />
+          </div>
+
+          <div class="flex min-w-0 max-w-[26rem] flex-1 items-center gap-3">
+            <span class="shrink-0 text-[11px] font-semibold uppercase tracking-[0.08em] text-on-surface-variant">
+              Active Environment
+            </span>
+            <Select
+              value={activeProject() ? getActiveEnvironmentName(activeProject()!.urlSlug) : ""}
+              onChange={handleEnvironmentChange}
+              options={environmentOptions()}
+              placeholder={
+                activeProject()
+                  ? environmentsQuery.isLoading
+                    ? "Loading environments..."
+                    : "Select an environment"
+                  : "Select a project first"
+              }
+              disabled={!activeProject() || environmentsQuery.isLoading}
+              class="h-9 w-full min-w-0 rounded-xl border-outline-variant/20 bg-surface-container-low text-[12px]"
+            />
+          </div>
         </div>
 
-        <div class="flex min-w-0 max-w-[26rem] flex-1 items-center gap-3">
-          <span class="shrink-0 text-[11px] font-semibold uppercase tracking-[0.08em] text-on-surface-variant">
-            Active Environment
-          </span>
-          <Select
-            value={activeProject() ? getActiveEnvironmentName(activeProject()!.urlSlug) : ""}
-            onChange={environmentName => {
-              const project = activeProject();
-              if (!project) {
-                return;
-              }
+        <div class="flex shrink-0 items-center gap-2">
+          <ThemeToggle />
 
-              if (environmentName === MANAGE_ENVIRONMENTS_OPTION) {
-                navigate(`/projects/${project.urlSlug}/environments`);
-                return;
-              }
+          <div class="h-5 w-px bg-outline-variant/20" />
 
-              setActiveEnvironmentName(project.urlSlug, environmentName);
-            }}
-            options={[
-              ...environments().map(environment => ({
-                value: environment.name,
-                label: environment.name,
-              })),
-              ...(activeProject()
-                ? [
-                    {
-                      value: MANAGE_ENVIRONMENTS_OPTION,
-                      label: "List or Create Environments",
-                    },
-                  ]
-                : []),
-            ]}
-            placeholder={
-              activeProject()
-                ? environmentsQuery.isLoading
-                  ? "Loading environments..."
-                  : "Select an environment"
-                : "Select a project first"
-            }
-            disabled={!activeProject() || environmentsQuery.isLoading}
-            class="h-9 w-full min-w-0 rounded-xl border-outline-variant/20 bg-surface-container-low text-[12px]"
-          />
+          <a
+            class="flex items-center gap-1 text-[11px] font-medium text-outline transition-colors hover:text-primary"
+            href="https://www.nonaconfig.com/support"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <span class="material-symbols-outlined text-[15px]">contact_support</span>
+            <span class="hidden md:inline">Support</span>
+          </a>
+          <a
+            class="flex items-center gap-1 text-[11px] font-medium text-outline transition-colors hover:text-primary"
+            href="https://www.nonaconfig.com/docs"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <span class="material-symbols-outlined text-[15px]">terminal</span>
+            <span class="hidden md:inline">API Docs</span>
+          </a>
         </div>
       </div>
 
-      <div class="flex items-center gap-2 shrink-0">
-        <ThemeToggle />
+      <div class="space-y-3 border-t border-outline-variant/10 px-5 py-3 md:px-7 lg:hidden">
+        <div class="grid gap-3 sm:grid-cols-2">
+          <div class="space-y-1.5">
+            <span class="block text-[11px] font-semibold uppercase tracking-[0.08em] text-on-surface-variant">
+              Active Project
+            </span>
+            <Select
+              value={getActiveProjectSlug()}
+              onChange={handleProjectChange}
+              options={projectOptions()}
+              placeholder={projectsQuery.isLoading ? "Loading projects..." : "Select a project"}
+              disabled={projectsQuery.isLoading || (projects().length === 0 && !canCreateProjects)}
+              class="h-10 w-full rounded-xl border-outline-variant/20 bg-surface-container-low text-[12px]"
+            />
+          </div>
 
-        <div class="w-px h-5 bg-outline-variant/20" />
-
-        <a
-          class="hover:text-primary transition-colors flex items-center gap-1 text-[11px] font-medium text-outline"
-          href="https://www.nonaconfig.com/support"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <span class="material-symbols-outlined text-[15px]">contact_support</span>
-          <span class="hidden md:inline">Support</span>
-        </a>
-        <a
-          class="hover:text-primary transition-colors flex items-center gap-1 text-[11px] font-medium text-outline"
-          href="https://www.nonaconfig.com/docs"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <span class="material-symbols-outlined text-[15px]">terminal</span>
-          <span class="hidden md:inline">API Docs</span>
-        </a>
+          <div class="space-y-1.5">
+            <span class="block text-[11px] font-semibold uppercase tracking-[0.08em] text-on-surface-variant">
+              Active Environment
+            </span>
+            <Select
+              value={activeProject() ? getActiveEnvironmentName(activeProject()!.urlSlug) : ""}
+              onChange={handleEnvironmentChange}
+              options={environmentOptions()}
+              placeholder={
+                activeProject()
+                  ? environmentsQuery.isLoading
+                    ? "Loading environments..."
+                    : "Select an environment"
+                  : "Select a project first"
+              }
+              disabled={!activeProject() || environmentsQuery.isLoading}
+              class="h-10 w-full rounded-xl border-outline-variant/20 bg-surface-container-low text-[12px]"
+            />
+          </div>
+        </div>
       </div>
     </header>
   );

--- a/admin/src/widgets/auth-shell/AuthCard.tsx
+++ b/admin/src/widgets/auth-shell/AuthCard.tsx
@@ -14,13 +14,13 @@ export const AuthCard: Component<AuthCardProps> = props => {
   return (
     <div
       data-testid={props.testId}
-      class="border-outline-variant/15 bg-surface-container-low animate-fade-in w-full max-w-105 overflow-hidden rounded-2xl border shadow-[0_0_50px_rgba(0,0,0,0.3)]"
+      class="animate-fade-in min-h-screen w-full max-w-none overflow-hidden rounded-none border-0 bg-transparent shadow-none sm:min-h-0 sm:max-w-105 sm:rounded-2xl sm:border sm:border-outline-variant/15 sm:bg-surface-container-low sm:shadow-[0_0_50px_rgba(0,0,0,0.3)]"
     >
-      <div class="flex flex-col justify-center p-8 md:p-10">
-        <div class="mx-auto w-full">
+      <div class="flex min-h-screen flex-col justify-start px-5 pb-8 pt-22 sm:min-h-0 sm:justify-center sm:p-8 md:p-10">
+        <div class="mx-auto w-full max-w-sm sm:max-w-none">
           {/* Brand Header */}
-          <div class="mb-8 flex flex-col items-center gap-3 text-center">
-            <div class="bg-primary/10 border-primary/20 text-primary flex h-10 w-10 items-center justify-center rounded-xl border shadow-[0_0_15px_rgba(99,102,241,0.15)]">
+          <div class="mb-8 flex flex-col items-start gap-3 text-left sm:items-center sm:text-center">
+            <div class="bg-primary/10 border-primary/20 text-primary flex h-11 w-11 items-center justify-center rounded-2xl border shadow-[0_0_15px_rgba(99,102,241,0.15)] sm:h-10 sm:w-10 sm:rounded-xl">
               <span
                 class="material-symbols-outlined text-lg font-bold"
                 style={{ "font-variation-settings": "'FILL' 1, 'wght' 400, 'GRAD' 0, 'opsz' 24" }}
@@ -34,21 +34,23 @@ export const AuthCard: Component<AuthCardProps> = props => {
           </div>
 
           {/* Title */}
-          <header class="mb-8 text-center">
+          <header class="mb-8 text-left sm:text-center">
             <h2
               data-testid={props.headingTestId}
-              class="font-headline text-on-surface mb-2 text-xl font-bold tracking-tight"
+              class="font-headline text-on-surface mb-2 text-[1.65rem] leading-tight font-bold tracking-tight sm:text-xl"
             >
               {props.title}
             </h2>
             <Show when={props.description}>
-              <p class="text-on-surface-variant text-xs leading-relaxed">{props.description}</p>
+              <p class="text-on-surface-variant max-w-[32ch] text-[13px] leading-relaxed sm:max-w-none sm:text-xs">
+                {props.description}
+              </p>
             </Show>
           </header>
 
           {/* Error */}
           <Show when={props.error}>
-            <div class="text-error bg-error-container/10 border-error/25 mb-6 flex items-center gap-2 rounded-lg border p-3 text-xs">
+            <div class="text-error bg-error-container/10 border-error/25 mb-6 flex items-center gap-2 rounded-xl border p-3 text-xs">
               <span class="material-symbols-outlined shrink-0 text-[16px]">error</span>
               <span class="font-medium">{props.error}</span>
             </div>

--- a/admin/src/widgets/auth-shell/AuthLayout.tsx
+++ b/admin/src/widgets/auth-shell/AuthLayout.tsx
@@ -3,14 +3,14 @@ import { ThemeToggle } from "../../shared/ui/ThemeToggle";
 
 export const AuthLayout: ParentComponent = (props) => {
   return (
-    <div class="relative min-h-screen flex flex-col items-center justify-center p-4 bg-background overflow-hidden">
+    <div class="relative flex min-h-screen flex-col items-stretch justify-start overflow-hidden bg-background p-0 sm:items-center sm:justify-center sm:p-4">
       <ThemeToggle class="absolute right-4 top-4 z-20" />
 
       {/* Ambient background glow orbs */}
-      <div class="absolute top-[-20%] left-[-20%] w-[60%] h-[60%] rounded-full bg-primary/10 blur-[150px] pointer-events-none" />
-      <div class="absolute bottom-[-20%] right-[-20%] w-[60%] h-[60%] rounded-full bg-primary-container/5 blur-[150px] pointer-events-none" />
+      <div class="pointer-events-none absolute top-[-18%] left-[-24%] h-[46%] w-[70%] rounded-full bg-primary/10 blur-[120px] sm:top-[-20%] sm:left-[-20%] sm:h-[60%] sm:w-[60%] sm:blur-[150px]" />
+      <div class="pointer-events-none absolute right-[-28%] bottom-[-14%] h-[38%] w-[70%] rounded-full bg-primary-container/5 blur-[120px] sm:right-[-20%] sm:bottom-[-20%] sm:h-[60%] sm:w-[60%] sm:blur-[150px]" />
       
-      <div class="relative z-10 w-full flex flex-col items-center justify-center">
+      <div class="relative z-10 flex min-h-screen w-full flex-col items-stretch justify-start sm:min-h-0 sm:items-center sm:justify-center">
         {props.children}
       </div>
     </div>

--- a/docs/src/content/docs/concepts/audit-logs.md
+++ b/docs/src/content/docs/concepts/audit-logs.md
@@ -39,7 +39,7 @@ In admin:
 2. open `Audit Logs` from the sidebar
 3. use `Filter audit trail...` to search by actor, target, or project
 4. use the `Action Type` and `Environment` filters to narrow the list
-5. click a row to open the details drawer
+5. read each row for the actor, action, target, environment, and time
 6. use `Export Logs` to download CSV or JSON
 
 The audit log page is the main operator workflow here. The repo does not currently expose a dedicated top-level CLI command for browsing audit logs.
@@ -81,7 +81,7 @@ When something changes unexpectedly in production:
 1. open `Audit Logs`
 2. filter to the relevant environment
 3. search for the key, project, or teammate involved
-4. open the matching row
+4. locate the matching entry in the list
 5. compare the audit event with the parameter history on the project page
 6. roll back the parameter if needed
 

--- a/docs/src/content/docs/concepts/environments.md
+++ b/docs/src/content/docs/concepts/environments.md
@@ -65,11 +65,15 @@ Public config reads use releases:
 - `version=1.1.0` reads that exact release
 - `version=1.1.x` reads the highest patch in the `1.1` line
 
-To publish a release, edit the working configuration, open the environment's `Releases` panel, enter a version such as `1.1.0`, and publish it.
+To publish a release, open the environment's `Releases` panel and choose **Create a version**. Enter a major-minor version such as `1.1`; Nona normalizes that to `1.1.0`, opens the parameters editor loaded with the current working configuration, and lets you adjust the parameters before choosing **Create release**.
 
-To patch an older line, create a working draft from an existing release, make the fix, and publish a new patch version such as `1.1.1`.
+Publishing does not change what clients receive. It only creates the snapshot. Use **Activate** on a release when you are ready for it to serve clients that omit a `version`.
+
+To patch an older line, choose **Amend** on that release. Nona automatically targets the next patch version, for example `1.1.1`, loads that release's parameters into the editor, and lets you snapshot your changes as the new patch. Amending replaces the editable working configuration with the selected release's parameters.
 
 Non-active releases can be permanently deleted from the release list. Clear or replace the active release before deleting it. Deleting a release does not change the editable working configuration.
+
+For the full release workflow, see [Releases](/docs/concepts/releases/).
 
 ## Common environment models
 
@@ -146,5 +150,6 @@ Firebase conditions can be mapped into Nona environments during migration, but N
 ## Related docs
 
 - [Projects](/docs/concepts/projects/)
+- [Releases](/docs/concepts/releases/)
 - [Create your first project](/docs/get-started/first-project/)
 - [Migrate from Firebase Remote Config](/docs/migration/firebase-remote-config/)

--- a/docs/src/content/docs/concepts/index.md
+++ b/docs/src/content/docs/concepts/index.md
@@ -14,6 +14,7 @@ At a high level, Nona works like this:
 - a project represents one app or service boundary
 - environments separate runtime stages like staging and production
 - entries store typed values
+- releases snapshot environment config for client reads
 - scopes control who should be allowed to read them
 - API keys control application access
 
@@ -41,6 +42,7 @@ After that, the terms in this section stop being abstract because you have alrea
 
 - [Projects](/docs/concepts/projects/)
 - [Environments](/docs/concepts/environments/)
+- [Releases](/docs/concepts/releases/)
 - [Parameters and content types](/docs/concepts/parameters-and-content-types/)
 - [Client vs server scope](/docs/concepts/client-vs-server-scope/)
 - [API keys](/docs/concepts/api-keys/)

--- a/docs/src/content/docs/concepts/releases.md
+++ b/docs/src/content/docs/concepts/releases.md
@@ -1,0 +1,181 @@
+---
+title: Releases
+description: Learn how Nona working configuration, immutable releases, active releases, and amend flow fit together.
+---
+
+Nona separates editing from serving.
+
+Each environment has:
+
+- one editable **working configuration**
+- zero or more immutable **releases**
+- one optional **active release**
+
+That model lets you prepare changes safely before clients receive them.
+
+## The release model
+
+Think of the environment in two layers:
+
+- the **Parameters** page is the editable working configuration
+- the **Releases** page is the history of immutable snapshots
+
+Applications read from releases, not directly from the editable working configuration.
+
+That means you can change parameters, review them, and only publish a release when you are ready.
+
+## How clients resolve versions
+
+Public reads work like this:
+
+- no `version` parameter reads the environment's active release
+- `version=1.2.0` reads that exact release
+- `version=1.2.x` reads the highest patch in the `1.2` line
+
+This gives you a stable exact-version path and a practical major-minor line path.
+
+## Working configuration vs active release
+
+Editing a parameter does **not** automatically change what clients receive.
+
+The editable working configuration is where operators prepare the next release.
+
+Clients only see:
+
+- the active release when they omit `version`
+- the exact or line-matched release when they request one explicitly
+
+That separation is one of the main safety properties of the release system.
+
+## Create a release
+
+In admin:
+
+1. open a project
+2. switch to the target environment
+3. open `Releases`
+4. click **Create a version**
+5. enter a major-minor version such as `1.2`
+6. continue to the Parameters page
+7. review or adjust the working configuration
+8. click **Create release**
+
+Nona normalizes the entered version to patch `.0`, so `1.2` becomes `1.2.0`.
+
+Creating the release stores an immutable snapshot of the current working configuration.
+
+## Activate a release
+
+Creating a release does not auto-activate it.
+
+Activation is a separate deliberate step:
+
+1. open `Releases`
+2. find the release you want clients to use by default
+3. click **Activate**
+
+After that, clients that omit `version` read that active release.
+
+## Amend an older release line
+
+Use **Amend** when you need a new patch from an older release line.
+
+For example:
+
+- `1.1.0` amended becomes `1.1.1`
+- if `1.1.1` already exists, the next amend becomes `1.1.2`
+
+In admin:
+
+1. open `Releases`
+2. click **Amend** on the source release
+3. Nona loads that release into the working configuration
+4. Nona automatically targets the next free patch in that line
+5. review the parameters
+6. click **Create release**
+
+Amend does not ask you to type the patch version manually.
+
+## Important amend behavior
+
+Amending replaces the editable working configuration with the source release's parameters.
+
+That is useful when you want to patch an older line, but it also means the current working configuration is overwritten.
+
+If you need to preserve unrelated unpublished work, finish or capture that work first.
+
+## Delete a release
+
+Non-active releases can be deleted from the release list.
+
+Deleting a release:
+
+- removes that immutable snapshot
+- does not change the editable working configuration
+- requires the release to not be the active release
+
+If the release is active, activate a different release or clear the active release first.
+
+## Good release habits
+
+- treat the Parameters page as the workspace for the next release
+- activate releases separately from creating them
+- use exact versions for strongly pinned consumers
+- use `major.minor.x` line reads when clients should float to the newest patch
+- amend older lines only when you intentionally want to patch that line
+
+## Practical example
+
+One common flow looks like this:
+
+1. `production` has active release `1.1.0`
+2. operators prepare the next working changes
+3. they create version `1.2`
+4. Nona composes `1.2.0`
+5. they create the release
+6. they activate `1.2.0` when ready
+
+Later, if `1.1.0` needs a backport fix:
+
+1. they click **Amend** on `1.1.0`
+2. Nona targets `1.1.1`
+3. they adjust the parameters
+4. they create `1.1.1`
+
+That keeps release lines explicit and understandable.
+
+## FAQ
+
+### Does editing parameters immediately affect clients?
+
+No.
+
+Editing changes the working configuration only. Clients read releases.
+
+### Why does Create a version ask for `1.2` instead of `1.2.0`?
+
+Because the admin flow treats the first release in a line as patch `.0` automatically.
+
+That keeps version entry simpler while still storing full release versions.
+
+### Does creating a release activate it automatically?
+
+No.
+
+Activation is a separate explicit action.
+
+### What does Amend do?
+
+Amend loads an existing release into the working configuration and targets the next free patch in that same line.
+
+### Can I patch an older release line without typing the next patch version?
+
+Yes.
+
+That is what Amend does automatically.
+
+## Related docs
+
+- [Environments](/docs/concepts/environments/)
+- [Parameters and content types](/docs/concepts/parameters-and-content-types/)
+- [History and rollback](/docs/concepts/history-and-rollback/)

--- a/docs/src/content/docs/parameter-share-links.md
+++ b/docs/src/content/docs/parameter-share-links.md
@@ -27,6 +27,8 @@ Choose the shortest lifetime that still fits the task. In most cases, short-live
 
 The admin dialog also lets you generate a new link, copy the generated URL, review existing links for that parameter, and revoke an active link.
 
+If you need an environment-wide view, the admin also has a dedicated **Shared Links** page inside each project that lists all share links for the currently active environment.
+
 ## Create a link with the CLI
 
 ```bash
@@ -84,6 +86,7 @@ nona entries share revoke \
 ```
 
 In admin, revocation is handled from the same share dialog that lists the existing links.
+The dedicated Shared Links page can also copy and revoke links across the active environment.
 
 ## Good use cases
 

--- a/docs/src/route-data.ts
+++ b/docs/src/route-data.ts
@@ -370,6 +370,28 @@ const PAGE_FAQS: Record<string, FaqItem[]> = {
 				'No. Firebase conditions can be mapped into Nona environments during migration, but Nona environments are not a Firebase-style runtime targeting engine.',
 		},
 	],
+	'concepts/releases': [
+		{
+			question: 'Does editing parameters immediately affect clients?',
+			answer:
+				'No. Editing changes the working configuration only. Clients read releases, either the active release or an explicitly requested version.',
+		},
+		{
+			question: 'Why does Create a version ask for 1.2 instead of 1.2.0?',
+			answer:
+				'Because the admin flow treats the first release in a line as patch .0 automatically, which keeps version entry simpler while still storing full release versions.',
+		},
+		{
+			question: 'Does creating a release activate it automatically?',
+			answer:
+				'No. Activation is a separate deliberate action on the Releases page.',
+		},
+		{
+			question: 'What does Amend do?',
+			answer:
+				'Amend loads an existing release into the working configuration and targets the next free patch in that same line.',
+		},
+	],
 	'concepts/parameters-and-content-types': [
 		{
 			question: 'What is the best first parameter type to create?',


### PR DESCRIPTION
This PR reworks the Nona admin around a project-first workflow, simplifies release handling, and does a broad mobile/UI consistency pass across the app.
Replaced the old dashboard-oriented navigation with project/environment context in the header, moved lower-priority nav items, and aligned page structure so each project page owns its own header/actions.
Simplified project pages:parameters split into dedicated views and now support release snapshot viewing on the parameters page
environments got a proper list page
API keys, releases, and shared links were brought into the same page pattern

Updated the release workflow:create release now starts from major.minor only
amend auto-increments the next patch version
added a read-only “view release parameters” flow that opens the parameters page in release-snapshot mode
added confirmations for activating and clearing active releases

Cleaned up parameter editing:moved away from the slow right sidebar toward inline/accordion editing
improved JSON editing behavior
merged environment + active version context into parameter editing
added production warning affordances

Standardized styling:adopted the blue/green palette (rgb(96, 165, 250) / rgb(52, 211, 153))
removed inconsistent project header blocks
aligned create forms and action buttons across pages
added lots of mobile-specific cleanup: icon-only actions, same-row search/action bars, mobile cards for parameters and team members, and a better full-screen auth experience

Documentation updates:added dedicated release docs in nona-config/docs
updated related docs like environments and shared links
added a release article in nona-landing
refreshed admin handoff/readme docs

Notable user-facing outcomes
Active project/environment selection is persistent and mobile-accessible.
Empty states now auto-open the relevant create form where appropriate.
Releases are easier to create, inspect, amend, activate, and document.
Mobile admin usability is substantially better across parameters, projects, team, audit logs, releases, environments, API keys, and auth.
Validation
```
npx tsc -b
npm run build where relevant
targeted vitest integration suites for project and users flows
docs and landing builds passed earlier in the change set
```