### PR TITLE
Demo page created

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 **Self-hosted feature flags and remote configuration for web, mobile, and backend apps.**
 
+[![Live demo](https://img.shields.io/badge/Live_demo-demo.nonaconfig.com-5b6ef5?style=flat-square&logo=googlechrome&logoColor=white)](https://demo.nonaconfig.com)
 [![Docker Pulls](https://img.shields.io/docker/pulls/rywaredev/nona?style=flat-square&logo=docker)](https://hub.docker.com/r/rywaredev/nona)
 [![npm](https://img.shields.io/npm/v/nona-client?style=flat-square&logo=npm)](https://www.npmjs.com/package/nona-client)
 [![NuGet](https://img.shields.io/nuget/v/Nona.Client?style=flat-square&logo=nuget)](https://www.nuget.org/packages/Nona.Client)
@@ -15,6 +16,12 @@ Nona gives you the same feature flag and remote config capabilities as Firebase 
 - Update **mobile app config** (iOS, Android, React Native, Flutter) without an app store release
 - Use **kill switches** to disable broken features in seconds
 - Fetch everything via **one REST API call** — no SDK required in any language
+
+### ▶ [Try the live demo](https://demo.nonaconfig.com)
+
+A real Nona instance with sample projects, environments and releases. You are signed in
+automatically as an administrator — no account, no install. Everything resets nightly,
+so change whatever you like.
 
 > 🌐 [nonaconfig.com](https://nonaconfig.com) &nbsp;·&nbsp; 🐳 [Docker Hub](https://hub.docker.com/r/rywaredev/nona) &nbsp;·&nbsp; 📦 [npm](https://www.npmjs.com/package/nona-client) &nbsp;·&nbsp; 📦 [NuGet](https://www.nuget.org/packages/Nona.Client)
 
@@ -60,6 +67,8 @@ Nona runs as a single Docker container with SQLite in standalone mode and embedd
 ---
 
 ## Quick Start
+
+Want to look around before installing anything? [Try the live demo](https://demo.nonaconfig.com).
 
 ```bash
 docker run -d \

--- a/deploy/demo/.gitattributes
+++ b/deploy/demo/.gitattributes
@@ -1,0 +1,4 @@
+*.sh text eol=lf
+*.env text eol=lf
+*.html text eol=lf
+systemd/* text eol=lf

--- a/deploy/demo/.gitignore
+++ b/deploy/demo/.gitignore
@@ -1,0 +1,2 @@
+demo.env
+demo-info.json

--- a/deploy/demo/demo-login.html
+++ b/deploy/demo/demo-login.html
@@ -1,0 +1,123 @@
+<!doctype html>
+<html lang="en" class="dark" data-theme="dark">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Nona Demo</title>
+<meta name="robots" content="noindex" />
+<style>
+  :root { color-scheme: dark; }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; min-height: 100vh; display: grid; place-items: center;
+    background: #0f1115; color: #e6e8ee;
+    font: 15px/1.55 ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    padding: 24px;
+  }
+  .card {
+    width: 100%; max-width: 400px; text-align: center;
+    background: #161922; border: 1px solid #262b38; border-radius: 16px;
+    padding: 40px 32px;
+  }
+  h1 { margin: 0 0 6px; font-size: 19px; font-weight: 600; letter-spacing: -0.01em; }
+  p  { margin: 0; color: #98a0b3; font-size: 13px; }
+  .spinner {
+    width: 30px; height: 30px; margin: 0 auto 22px;
+    border: 2.5px solid #2b3142; border-top-color: #5b6ef5; border-radius: 50%;
+    animation: spin 0.75s linear infinite;
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
+  .note {
+    margin-top: 22px; padding-top: 18px; border-top: 1px solid #262b38;
+    font-size: 11.5px; color: #6f7688;
+  }
+  a { color: #8b9bff; }
+  .error { display: none; }
+  .error code {
+    display: block; margin: 12px 0 16px; padding: 9px 11px;
+    background: #0f1115; border: 1px solid #262b38; border-radius: 8px;
+    font-size: 12px; color: #c8cdda;
+  }
+  .btn {
+    display: inline-block; margin-top: 4px; padding: 9px 18px;
+    background: #5b6ef5; color: #fff; border-radius: 9px;
+    font-size: 13px; font-weight: 500; text-decoration: none;
+  }
+  [hidden] { display: none !important; }
+</style>
+</head>
+<body>
+  <main class="card">
+    <div id="loading">
+      <div class="spinner"></div>
+      <h1>Opening the demo</h1>
+      <p>Signing you in as a demo administrator…</p>
+    </div>
+
+    <div id="failed" class="error">
+      <h1>Could not sign you in automatically</h1>
+      <p>Use these credentials on the login page:</p>
+      <code id="creds"></code>
+      <a class="btn" href="/login">Go to login</a>
+    </div>
+
+    <div class="note">
+      Public sandbox — everything you change is wiped nightly.
+      <br />
+      <a href="https://nonaconfig.com/docs" target="_blank" rel="noopener">Docs</a> ·
+      <a href="https://github.com/ryware/nona-config" target="_blank" rel="noopener">Source</a>
+    </div>
+  </main>
+
+<script>
+  var EMAIL = "__DEMO_EMAIL__";
+  var PASSWORD = "__DEMO_PASSWORD__";
+
+  function isAdminFromToken(token) {
+    try {
+      var parts = token.split(".");
+      if (parts.length !== 3) return false;
+      var claim = JSON.parse(atob(parts[1].replace(/-/g, "+").replace(/_/g, "/"))).isAdmin;
+      return claim === true || claim === "true";
+    } catch (error) {
+      return false;
+    }
+  }
+
+  function saveSession(login) {
+    localStorage.setItem("auth_token", login.token);
+    localStorage.setItem("auth_session", JSON.stringify({
+      email: login.username || EMAIL,
+      role: login.role,
+      isAdmin: isAdminFromToken(login.token)
+    }));
+  }
+
+  function fail() {
+    document.getElementById("creds").textContent = EMAIL + "  /  " + PASSWORD;
+    document.getElementById("loading").hidden = true;
+    document.getElementById("failed").style.display = "block";
+  }
+
+  fetch("/auth/login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email: EMAIL, password: PASSWORD })
+  })
+    .then(function (response) {
+      if (!response.ok) throw new Error("login failed: " + response.status);
+      return response.json();
+    })
+    .then(function (login) {
+      if (!login || !login.token) throw new Error("no token in response");
+      saveSession(login);
+      // replace() so Back does not bounce the visitor through this page again.
+      location.replace("/projects");
+    })
+    .catch(function (error) {
+      console.error(error);
+      fail();
+    });
+</script>
+</body>
+</html>

--- a/deploy/demo/demo.env.example
+++ b/deploy/demo/demo.env.example
@@ -1,0 +1,1 @@
+NONA_DEMO_EMAIL=demo@nonaconfig.com

--- a/deploy/demo/deploy.sh
+++ b/deploy/demo/deploy.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# Creates the demo VM. e2-micro + 30 GB pd-standard in us-central1 are free tier;
+# the static IPv4 is the only charge (~$3/mo). Re-runnable.
+#
+#   ./deploy.sh
+#   ./deploy.sh --domain demo.example.com --zone us-east1-b
+#   PROJECT_ID=other-proj ./deploy.sh
+
+set -euo pipefail
+
+PROJECT_ID="${PROJECT_ID:-ryware}"
+ZONE="${ZONE:-us-central1-a}"
+NAME="${NAME:-nona-demo}"
+DOMAIN="${DOMAIN:-demo.nonaconfig.com}"
+ACME_EMAIL="${ACME_EMAIL:-michael@ryware.dev}"
+IMAGE="${IMAGE:-rywaredev/nona:latest}"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --project) PROJECT_ID="$2"; shift 2 ;;
+    --zone)    ZONE="$2";       shift 2 ;;
+    --name)    NAME="$2";       shift 2 ;;
+    --domain)  DOMAIN="$2";     shift 2 ;;
+    --email)   ACME_EMAIL="$2"; shift 2 ;;
+    --image)   IMAGE="$2";      shift 2 ;;
+    -h|--help) sed -n '2,7p' "$0"; exit 0 ;;
+    *) echo "unknown option: $1" >&2; exit 1 ;;
+  esac
+done
+
+REGION="${ZONE%-*}"
+IP_NAME="$NAME-ip"
+FW_NAME="$NAME-web"
+TAG="$NAME"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STARTUP="$SCRIPT_DIR/startup-script.sh"
+
+step() { printf '\n\033[36m==> %s\033[0m\n' "$1"; }
+note() { printf '    %s\n' "$1"; }
+
+[ -f "$STARTUP" ] || { echo "startup-script.sh not found next to this script" >&2; exit 1; }
+
+step "Project $PROJECT_ID / zone $ZONE"
+gcloud config set project "$PROJECT_ID" >/dev/null
+
+step "Enabling the Compute Engine API (no-op if already on)"
+gcloud services enable compute.googleapis.com --project "$PROJECT_ID"
+
+# --- static external IP -------------------------------------------------
+# Costs the same as ephemeral while attached, but survives a stop/start, so the
+# DNS record never goes stale.
+step "Reserving static IP $IP_NAME in $REGION"
+if [ -z "$(gcloud compute addresses list --project "$PROJECT_ID" \
+             --filter="name=$IP_NAME AND region:$REGION" --format='value(name)')" ]; then
+  gcloud compute addresses create "$IP_NAME" \
+    --project "$PROJECT_ID" --region "$REGION" --network-tier STANDARD
+else
+  note "already reserved"
+fi
+IP="$(gcloud compute addresses describe "$IP_NAME" \
+        --project "$PROJECT_ID" --region "$REGION" --format='value(address)' | tr -d '[:space:]')"
+printf '    \033[32mIP: %s\033[0m\n' "$IP"
+
+# --- firewall -----------------------------------------------------------
+# 80/443 only; Nona's 8080 is never exposed. SSH rides default-allow-ssh.
+step "Firewall rule $FW_NAME (tcp:80,443 -> tag '$TAG')"
+if [ -z "$(gcloud compute firewall-rules list --project "$PROJECT_ID" \
+             --filter="name=$FW_NAME" --format='value(name)')" ]; then
+  gcloud compute firewall-rules create "$FW_NAME" \
+    --project "$PROJECT_ID" \
+    --allow tcp:80,tcp:443 \
+    --target-tags "$TAG" \
+    --source-ranges 0.0.0.0/0 \
+    --description 'Nona demo: HTTP/HTTPS to Caddy'
+else
+  note "already exists"
+fi
+
+# --- the VM -------------------------------------------------------------
+step "Creating VM $NAME (e2-micro, Debian 12, 30 GB pd-standard)"
+if [ -z "$(gcloud compute instances list --project "$PROJECT_ID" \
+             --filter="name=$NAME AND zone:$ZONE" --format='value(name)')" ]; then
+  gcloud compute instances create "$NAME" \
+    --project "$PROJECT_ID" \
+    --zone "$ZONE" \
+    --machine-type e2-micro \
+    --image-family debian-12 \
+    --image-project debian-cloud \
+    --boot-disk-size 30GB \
+    --boot-disk-type pd-standard \
+    --network-tier STANDARD \
+    --address "$IP" \
+    --tags "$TAG" \
+    --metadata "nona-domain=$DOMAIN,nona-acme-email=$ACME_EMAIL,nona-image=$IMAGE" \
+    --metadata-from-file "startup-script=$STARTUP" \
+    --labels "app=nona,env=demo"
+else
+  note "already exists - updating metadata and re-running the startup script"
+  gcloud compute instances add-metadata "$NAME" --project "$PROJECT_ID" --zone "$ZONE" \
+    --metadata "nona-domain=$DOMAIN,nona-acme-email=$ACME_EMAIL,nona-image=$IMAGE" \
+    --metadata-from-file "startup-script=$STARTUP"
+  gcloud compute ssh "$NAME" --project "$PROJECT_ID" --zone "$ZONE" \
+    --command 'sudo google_metadata_script_runner startup'
+fi
+
+# --- demo layer ---------------------------------------------------------
+# Uploaded rather than baked into metadata, so seed data and the landing page can
+# be re-pushed on their own.
+step "Installing the demo layer (seed data, auto-login page, nightly reset)"
+
+# scp is pscp on Windows, which won't expand '~'.
+REMOTE_HOME="$(gcloud compute ssh "$NAME" --project "$PROJECT_ID" --zone "$ZONE" --quiet \
+  --command 'echo $HOME' | tr -d '\r' | tail -1)"
+STAGING="$REMOTE_HOME/demo-src"
+note "staging at $STAGING"
+
+gcloud compute ssh "$NAME" --project "$PROJECT_ID" --zone "$ZONE" --quiet \
+  --command "mkdir -p '$STAGING/systemd'"
+
+gcloud compute scp \
+  "$SCRIPT_DIR/seed.sh" "$SCRIPT_DIR/reset.sh" "$SCRIPT_DIR/demo.env.example" \
+  "$SCRIPT_DIR/demo-login.html" "$SCRIPT_DIR/install-demo.sh" \
+  "$NAME:$STAGING/" --project "$PROJECT_ID" --zone "$ZONE" --quiet
+
+gcloud compute scp \
+  "$SCRIPT_DIR/systemd/nona-demo-reset.service" "$SCRIPT_DIR/systemd/nona-demo-reset.timer" \
+  "$NAME:$STAGING/systemd/" --project "$PROJECT_ID" --zone "$ZONE" --quiet
+
+gcloud compute ssh "$NAME" --project "$PROJECT_ID" --zone "$ZONE" --quiet \
+  --command "chmod +x '$STAGING'/*.sh && sudo '$STAGING/install-demo.sh'"
+
+step "Seeding the demo workspace"
+gcloud compute ssh "$NAME" --project "$PROJECT_ID" --zone "$ZONE" --quiet \
+  --command 'sudo systemctl start nona-demo-reset.service && sudo journalctl -u nona-demo-reset.service -n 25 --no-pager'
+
+cat <<EOF
+
+$(printf '\033[32m')======================================================================
+ VM is up. Point DNS at it, then wait for Caddy to get a certificate.
+======================================================================$(printf '\033[0m')
+
+  GoDaddy DNS for nonaconfig.com - add:
+      Type: A     Name: ${DOMAIN%%.*}     Value: $IP     TTL: 600
+
+  Then:  https://$DOMAIN
+
+  Watch the bootstrap:
+      gcloud compute ssh $NAME --zone $ZONE --command 'sudo tail -f /var/log/nona-startup.log'
+  Check the containers:
+      gcloud compute ssh $NAME --zone $ZONE --command 'cd /opt/nona && sudo docker compose ps'
+  Reset now:
+      gcloud compute ssh $NAME --zone $ZONE --command 'sudo systemctl start nona-demo-reset.service'
+
+  Tear down - all three, or the released-but-unattached IP bills more than it does now:
+      gcloud compute instances delete $NAME --zone $ZONE --quiet
+      gcloud compute addresses delete $IP_NAME --region $REGION --quiet
+      gcloud compute firewall-rules delete $FW_NAME --quiet
+
+EOF

--- a/deploy/demo/install-demo.sh
+++ b/deploy/demo/install-demo.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Installs the demo layer on the VM. Run by deploy.sh over SSH; re-run to pick up edits.
+
+set -euo pipefail
+
+SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR=/opt/nona
+DEMO_DIR="$APP_DIR/demo"
+
+step() { printf '\n==> %s\n' "$1"; }
+
+step "Installing demo files to $DEMO_DIR"
+mkdir -p "$DEMO_DIR"
+install -m 0700 "$SRC/seed.sh"  "$DEMO_DIR/seed.sh"
+install -m 0700 "$SRC/reset.sh" "$DEMO_DIR/reset.sh"
+
+# Generated here rather than committed. Kept once created: the account is registered
+# with it, so changing it without a reseed locks the landing page out.
+if [ ! -f "$DEMO_DIR/demo.env" ]; then
+  step "Generating demo credentials"
+  # Shape satisfies Nona's policy: length, uppercase, digit, symbol.
+  GENERATED="Demo-$(openssl rand -hex 8)!A1"
+  EMAIL_DEFAULT="$(grep -E '^NONA_DEMO_EMAIL=' "$SRC/demo.env.example" | cut -d= -f2-)"
+  {
+    echo "# Generated on first install. Public by design - see demo.env.example."
+    echo "NONA_DEMO_EMAIL=${EMAIL_DEFAULT:-demo@nonaconfig.com}"
+    echo "NONA_DEMO_PASSWORD=$GENERATED"
+  } > "$DEMO_DIR/demo.env"
+  chmod 600 "$DEMO_DIR/demo.env"
+  echo "  generated for ${EMAIL_DEFAULT:-demo@nonaconfig.com}"
+fi
+
+# demo.env is the single source; the page gets its copy substituted in here.
+. "$DEMO_DIR/demo.env"
+sed -e "s|__DEMO_EMAIL__|${NONA_DEMO_EMAIL}|g" \
+    -e "s|__DEMO_PASSWORD__|${NONA_DEMO_PASSWORD}|g" \
+    "$SRC/demo-login.html" > "$DEMO_DIR/index.html"
+chmod 0644 "$DEMO_DIR/index.html"
+
+step "Installing the nightly reset timer"
+install -m 0644 "$SRC/systemd/nona-demo-reset.service" /etc/systemd/system/
+install -m 0644 "$SRC/systemd/nona-demo-reset.timer"   /etc/systemd/system/
+systemctl daemon-reload
+systemctl enable --now nona-demo-reset.timer
+
+step "Reloading Caddy so it serves the landing page"
+cd "$APP_DIR"
+docker compose up -d
+
+printf '\n==> Installed. Next reset:\n'
+systemctl list-timers nona-demo-reset.timer --no-pager | sed -n '1,2p'

--- a/deploy/demo/reset.sh
+++ b/deploy/demo/reset.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Wipes and reseeds the demo. Destroys the volume rather than deleting rows, so
+# nothing a visitor did survives. Fired nightly by nona-demo-reset.timer.
+
+set -euo pipefail
+
+APP_DIR="${APP_DIR:-/opt/nona}"
+DEMO_DIR="${DEMO_DIR:-/opt/nona/demo}"
+DATA_VOLUME="${DATA_VOLUME:-nona_nona-data}"
+
+log() { printf '[%s] %s\n' "$(date -Is)" "$1"; }
+
+cd "$APP_DIR"
+
+log "Stopping the stack"
+docker compose down
+
+log "Removing the data volume ($DATA_VOLUME)"
+docker volume rm "$DATA_VOLUME" >/dev/null 2>&1 || log "volume was already absent"
+
+log "Starting the stack"
+docker compose up -d
+
+log "Seeding"
+# Over loopback, so a reset never depends on DNS, TLS, or the box being reachable.
+DEMO_INFO_DIR="$DEMO_DIR" \
+BASE_URL="http://127.0.0.1:18080" \
+ENV_FILE="$DEMO_DIR/demo.env" \
+  "$DEMO_DIR/seed.sh"
+
+log "Reset complete"

--- a/deploy/demo/seed.sh
+++ b/deploy/demo/seed.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+# Seeds the demo workspace over Nona's HTTP API - no demo code in the product.
+# Relies on /auth/register creating the first admin and refusing thereafter, which
+# is the state a freshly wiped database is in.
+#
+#   ./seed.sh
+#   BASE_URL=https://demo.nonaconfig.com ./seed.sh
+
+set -euo pipefail
+
+BASE_URL="${BASE_URL:-http://127.0.0.1:8080}"
+ENV_FILE="${ENV_FILE:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/demo.env}"
+
+[ -f "$ENV_FILE" ] && . "$ENV_FILE"
+EMAIL="${NONA_DEMO_EMAIL:?set NONA_DEMO_EMAIL}"
+PASSWORD="${NONA_DEMO_PASSWORD:?set NONA_DEMO_PASSWORD}"
+
+TOKEN=""
+
+log()  { printf '  %s\n' "$1"; }
+step() { printf '\n==> %s\n' "$1"; }
+
+# --- plumbing -----------------------------------------------------------
+
+# api METHOD PATH [JSON_BODY]
+api() {
+  local method="$1" path="$2" body="${3:-}"
+  local args=(-sS -X "$method" "$BASE_URL$path" -H 'Content-Type: application/json')
+  [ -n "$TOKEN" ] && args+=(-H "Authorization: Bearer $TOKEN")
+  [ -n "$body" ] && args+=(-d "$body")
+  curl "${args[@]}"
+}
+
+wait_for_api() {
+  step "Waiting for Nona at $BASE_URL"
+  for _ in $(seq 1 60); do
+    if curl -sS -o /dev/null --max-time 3 "$BASE_URL/auth/first-time" 2>/dev/null; then
+      log "up"
+      return 0
+    fi
+    sleep 2
+  done
+  echo "Nona did not become reachable at $BASE_URL" >&2
+  exit 1
+}
+
+authenticate() {
+  step "Authenticating as $EMAIL"
+  local payload response
+  payload="$(jq -nc --arg e "$EMAIL" --arg p "$PASSWORD" '{email:$e,password:$p}')"
+
+  # Fresh database -> register. Already seeded -> log in.
+  response="$(api POST /auth/register "$payload")"
+  TOKEN="$(jq -r '.token // empty' <<<"$response")"
+  if [ -n "$TOKEN" ]; then
+    log "registered the first admin account"
+    return
+  fi
+
+  response="$(api POST /auth/login "$payload")"
+  TOKEN="$(jq -r '.token // empty' <<<"$response")"
+  if [ -z "$TOKEN" ]; then
+    echo "Could not register or log in. Last response: $response" >&2
+    exit 1
+  fi
+  log "logged in to the existing instance"
+}
+
+# --- resource helpers ---------------------------------------------------
+
+create_project() {
+  local name="$1" response
+  response="$(api POST /admin/projects "$(jq -nc --arg n "$name" '{name:$n}')")"
+  if [ -z "$(jq -r '.name // empty' <<<"$response")" ]; then
+    echo "Failed to create project '$name': $response" >&2
+    exit 1
+  fi
+  log "project: $name"
+}
+
+# Creating a project auto-creates Defaults:Environment (Production), so hitting an
+# existing one here is expected rather than an error.
+create_environment() {
+  local project="$1" name="$2" response
+  response="$(api POST "/admin/projects/$project/environments" "$(jq -nc --arg n "$name" '{name:$n}')")"
+  if [ -n "$(jq -r '.name // empty' <<<"$response")" ]; then
+    log "environment: $project/$name"
+  else
+    log "environment: $project/$name (already present)"
+  fi
+}
+
+# set_param PROJECT ENV KEY VALUE CONTENT_TYPE [SCOPE]
+set_param() {
+  local project="$1" env="$2" key="$3" value="$4" content_type="$5" scope="${6:-all}"
+  local encoded_key payload response
+  encoded_key="$(jq -rn --arg k "$key" '$k|@uri')"
+  payload="$(jq -nc \
+    --arg v "$value" --arg c "$content_type" --arg s "$scope" \
+    '{value:$v,contentType:$c,scope:$s}')"
+
+  response="$(api PUT "/admin/projects/$project/environments/$env/config-entries/$encoded_key" "$payload")"
+  if [ -z "$(jq -r '.key // empty' <<<"$response")" ]; then
+    echo "Failed to set $project/$env/$key: $response" >&2
+    exit 1
+  fi
+}
+
+# publish_release PROJECT ENV VERSION MAKE_ACTIVE
+# Snapshots the environment's working parameters, so set the values you want first.
+publish_release() {
+  local project="$1" env="$2" version="$3" make_active="$4" payload response
+  payload="$(jq -nc --arg v "$version" --argjson a "$make_active" '{version:$v,makeActive:$a}')"
+  response="$(api POST "/admin/projects/$project/environments/$env/releases" "$payload")"
+  if [ -z "$(jq -r '.version // empty' <<<"$response")" ]; then
+    echo "Failed to publish $project/$env $version: $response" >&2
+    exit 1
+  fi
+  log "release: $project/$env $version$([ "$make_active" = true ] && echo ' (active)')"
+}
+
+# create_api_key PROJECT NAME SCOPE -> prints the generated key
+create_api_key() {
+  local project="$1" name="$2" scope="$3" payload response key
+  payload="$(jq -nc --arg n "$name" --arg s "$scope" '{name:$n,scope:$s}')"
+  response="$(api POST "/admin/projects/$project/api-keys" "$payload")"
+  key="$(jq -r '.key // empty' <<<"$response")"
+  if [ -z "$key" ]; then
+    echo "Failed to create API key for $project: $response" >&2
+    exit 1
+  fi
+  # stdout is the key itself, so progress has to go to stderr.
+  log "api key: $project/$name" >&2
+  printf '%s' "$key"
+}
+
+# --- the demo workspace -------------------------------------------------
+
+seed_storefront() {
+  step "Seeding 'acme-storefront'"
+  create_project "acme-storefront"
+  create_environment "acme-storefront" "Development"
+  create_environment "acme-storefront" "Staging"
+  create_environment "acme-storefront" "Production"
+
+  local palette='{"primary":"#5b6ef5","surface":"#0f1115","accent":"#f5a623","radius":12}'
+
+  set_param "acme-storefront" Development "Features:Checkout"              true                          boolean
+  set_param "acme-storefront" Development "Features:NewNavigation"         true                          boolean
+  set_param "acme-storefront" Development "Features:LiveChat"              true                          boolean
+  set_param "acme-storefront" Development "Killswitch:Payments"            false                         boolean
+  set_param "acme-storefront" Development "Checkout:MaxCartItems"          50                            number
+  set_param "acme-storefront" Development "Checkout:FreeShippingThreshold" 25                            number
+  set_param "acme-storefront" Development "Support:Email"                  dev-support@acme.example      text
+  set_param "acme-storefront" Development "Theme:Palette"                  "$palette"                    json
+  # Server-scoped: withheld from client-scoped API keys.
+  set_param "acme-storefront" Development "Payments:ProviderTimeoutMs"     30000                         number server
+
+  set_param "acme-storefront" Staging     "Features:Checkout"              true                          boolean
+  set_param "acme-storefront" Staging     "Features:NewNavigation"         true                          boolean
+  set_param "acme-storefront" Staging     "Features:LiveChat"              false                         boolean
+  set_param "acme-storefront" Staging     "Killswitch:Payments"            false                         boolean
+  set_param "acme-storefront" Staging     "Checkout:MaxCartItems"          25                            number
+  set_param "acme-storefront" Staging     "Checkout:FreeShippingThreshold" 50                            number
+  set_param "acme-storefront" Staging     "Support:Email"                  staging-support@acme.example  text
+  set_param "acme-storefront" Staging     "Theme:Palette"                  "$palette"                    json
+  set_param "acme-storefront" Staging     "Payments:ProviderTimeoutMs"     15000                         number server
+
+  # Release history: set values, publish, overwrite, publish again.
+  set_param "acme-storefront" Production  "Features:Checkout"              true                          boolean
+  set_param "acme-storefront" Production  "Features:NewNavigation"         false                         boolean
+  set_param "acme-storefront" Production  "Features:LiveChat"              false                         boolean
+  set_param "acme-storefront" Production  "Killswitch:Payments"            false                         boolean
+  set_param "acme-storefront" Production  "Checkout:MaxCartItems"          10                            number
+  set_param "acme-storefront" Production  "Checkout:FreeShippingThreshold" 100                           number
+  set_param "acme-storefront" Production  "Support:Email"                  support@acme.example          text
+  publish_release "acme-storefront" Production "1.0.0" false
+
+  set_param "acme-storefront" Production  "Features:LiveChat"              true                          boolean
+  set_param "acme-storefront" Production  "Checkout:MaxCartItems"          20                            number
+  set_param "acme-storefront" Production  "Checkout:FreeShippingThreshold" 75                            number
+  publish_release "acme-storefront" Production "1.1.0" false
+
+  set_param "acme-storefront" Production  "Theme:Palette"                  "$palette"                    json
+  set_param "acme-storefront" Production  "Payments:ProviderTimeoutMs"     10000                         number server
+  publish_release "acme-storefront" Production "1.2.0" true
+
+  # Published but not activated, so Staging keeps serving working parameters.
+  publish_release "acme-storefront" Staging "1.2.0" false
+
+  STOREFRONT_KEY="$(create_api_key "acme-storefront" "Web client key" client)"
+}
+
+seed_mobile() {
+  step "Seeding 'mobile-app'"
+  create_project "mobile-app"
+  create_environment "mobile-app" "Development"
+  create_environment "mobile-app" "Production"
+
+  set_param "mobile-app" Development "Features:BiometricLogin"    true          boolean
+  set_param "mobile-app" Development "Features:OfflineMode"       true          boolean
+  set_param "mobile-app" Development "Onboarding:Variant"         carousel      text
+  set_param "mobile-app" Development "App:MinimumSupportedVersion" 3.0.0        text
+  set_param "mobile-app" Development "App:Announcement" \
+    '{"visible":true,"title":"Dev build","body":"Pointing at the staging API.","severity":"info"}' json
+
+  set_param "mobile-app" Production  "Features:BiometricLogin"    true          boolean
+  set_param "mobile-app" Production  "Features:OfflineMode"       false         boolean
+  set_param "mobile-app" Production  "Onboarding:Variant"         single-screen text
+  set_param "mobile-app" Production  "App:MinimumSupportedVersion" 3.4.0        text
+  set_param "mobile-app" Production  "App:Announcement" \
+    '{"visible":false,"title":"","body":"","severity":"info"}' json
+  publish_release "mobile-app" Production "2.3.0" false
+
+  set_param "mobile-app" Production  "App:MinimumSupportedVersion" 3.4.1        text
+  publish_release "mobile-app" Production "2.4.0" true
+
+  MOBILE_KEY="$(create_api_key "mobile-app" "Mobile client key" client)"
+}
+
+# --- run ----------------------------------------------------------------
+
+command -v jq >/dev/null 2>&1 || { echo "jq is required" >&2; exit 1; }
+
+wait_for_api
+authenticate
+seed_storefront
+seed_mobile
+
+# Keys are server-generated and change on every reseed, so the landing page reads
+# them from here rather than hardcoding one.
+INFO_DIR="${DEMO_INFO_DIR:-}"
+if [ -n "$INFO_DIR" ] && [ -d "$INFO_DIR" ]; then
+  jq -nc \
+    --arg storefront "$STOREFRONT_KEY" \
+    --arg mobile "$MOBILE_KEY" \
+    '{storefrontApiKey:$storefront,mobileApiKey:$mobile}' > "$INFO_DIR/demo-info.json"
+  log "wrote $INFO_DIR/demo-info.json"
+fi
+
+cat <<EOF
+
+==> Demo workspace ready
+
+  Console : $BASE_URL
+  Sign in : $EMAIL / $PASSWORD
+
+  Try a read:
+    curl "$BASE_URL/api/Production/Features%3ACheckout" -H "X-Api-Key: $STOREFRONT_KEY"
+
+EOF

--- a/deploy/demo/startup-script.sh
+++ b/deploy/demo/startup-script.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+# VM bootstrap. Re-runs on every boot, so everything here is idempotent.
+set -euo pipefail
+
+exec > >(tee -a /var/log/nona-startup.log) 2>&1
+echo "=== nona startup $(date -Is) ==="
+
+APP_DIR=/opt/nona
+META="http://metadata.google.internal/computeMetadata/v1/instance/attributes"
+
+meta() { curl -fsS -H "Metadata-Flavor: Google" "$META/$1" 2>/dev/null || true; }
+
+NONA_DOMAIN="$(meta nona-domain)"
+ACME_EMAIL="$(meta nona-acme-email)"
+NONA_IMAGE="$(meta nona-image)"
+: "${NONA_IMAGE:=rywaredev/nona:latest}"
+
+# --- swap ---------------------------------------------------------------
+# 1 GB of RAM. Fits, but an apt upgrade or image pull can push it over.
+if [ ! -f /swapfile ]; then
+  echo "--- creating swap"
+  fallocate -l 2G /swapfile
+  chmod 600 /swapfile
+  mkswap /swapfile
+  echo '/swapfile none swap sw 0 0' >> /etc/fstab
+fi
+swapon /swapfile 2>/dev/null || true
+sysctl -w vm.swappiness=10 >/dev/null
+
+# --- docker -------------------------------------------------------------
+if ! command -v docker >/dev/null 2>&1; then
+  echo "--- installing docker"
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get update -qq
+  apt-get install -y -qq ca-certificates curl gnupg
+  install -m 0755 -d /etc/apt/keyrings
+  curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+  chmod a+r /etc/apt/keyrings/docker.asc
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+    > /etc/apt/sources.list.d/docker.list
+  apt-get update -qq
+  apt-get install -y -qq docker-ce docker-ce-cli containerd.io docker-compose-plugin
+fi
+systemctl enable --now docker
+
+command -v jq >/dev/null 2>&1 || DEBIAN_FRONTEND=noninteractive apt-get install -y -qq jq
+
+# The reset timer fires at local midnight.
+timedatectl set-timezone Asia/Jerusalem
+
+# Keep container logs from filling a 30 GB disk.
+mkdir -p /etc/docker
+cat > /etc/docker/daemon.json <<'JSON'
+{
+  "log-driver": "json-file",
+  "log-opts": { "max-size": "10m", "max-file": "3" }
+}
+JSON
+systemctl restart docker
+
+# --- app files ----------------------------------------------------------
+mkdir -p "$APP_DIR"
+cd "$APP_DIR"
+
+# Generated once. Rewriting the JWT key would invalidate every active session.
+if [ ! -f "$APP_DIR/.env" ]; then
+  echo "--- generating .env"
+  {
+    echo "NONA_IMAGE=$NONA_IMAGE"
+    echo "NONA_DOMAIN=$NONA_DOMAIN"
+    echo "ACME_EMAIL=$ACME_EMAIL"
+    echo "NONA_JWT_KEY=$(openssl rand -base64 48 | tr -d '\n')"
+  } > "$APP_DIR/.env"
+  chmod 600 "$APP_DIR/.env"
+else
+  sed -i "s|^NONA_IMAGE=.*|NONA_IMAGE=$NONA_IMAGE|" "$APP_DIR/.env"
+  sed -i "s|^NONA_DOMAIN=.*|NONA_DOMAIN=$NONA_DOMAIN|" "$APP_DIR/.env"
+  sed -i "s|^ACME_EMAIL=.*|ACME_EMAIL=$ACME_EMAIL|" "$APP_DIR/.env"
+fi
+
+cat > "$APP_DIR/Caddyfile" <<'CADDY'
+{
+	email {$ACME_EMAIL}
+}
+
+{$NONA_DOMAIN} {
+	encode zstd gzip
+
+	# A path matcher without a wildcard is exact, so this catches only the bare
+	# root - /projects, /login and the API all fall through to Nona.
+	handle / {
+		root * /srv/demo
+		rewrite * /index.html
+		# Runs once and redirects; without this browsers cache it heuristically.
+		header Cache-Control "no-store"
+		file_server
+	}
+
+	# Rewritten by every reset, so a cached copy would hand out a dead key.
+	handle /demo-info.json {
+		root * /srv/demo
+		header Cache-Control "no-store"
+		file_server
+	}
+
+	handle {
+		reverse_proxy nona:8080
+	}
+}
+CADDY
+
+# Caddy mounts this, so it has to exist before the demo layer is installed.
+mkdir -p "$APP_DIR/demo"
+
+cat > "$APP_DIR/docker-compose.yml" <<'COMPOSE'
+services:
+  nona:
+    image: ${NONA_IMAGE}
+    restart: unless-stopped
+    ports:
+      # Loopback: reachable by seed.sh and reset.sh, never from the internet.
+      - "127.0.0.1:18080:8080"
+    environment:
+      Jwt__Key: ${NONA_JWT_KEY}
+      Jwt__Issuer: nona
+      Jwt__Audience: nona
+    volumes:
+      - nona-data:/var/lib/nona
+
+  caddy:
+    image: caddy:2-alpine
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      NONA_DOMAIN: ${NONA_DOMAIN}
+      ACME_EMAIL: ${ACME_EMAIL}
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - ./demo:/srv/demo:ro
+      - caddy-data:/data
+      - caddy-config:/config
+    depends_on:
+      - nona
+
+volumes:
+  nona-data:
+  caddy-data:
+  caddy-config:
+COMPOSE
+
+echo "--- starting stack"
+docker compose pull --quiet
+docker compose up -d
+
+# `up -d` only restarts a container whose compose definition changed, so a Caddyfile
+# edit alone is otherwise ignored until the next reboot.
+echo "--- reloading Caddy config"
+docker compose exec -T caddy caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile \
+  || docker compose restart caddy
+
+echo "=== nona startup complete $(date -Is) ==="

--- a/deploy/demo/systemd/nona-demo-reset.service
+++ b/deploy/demo/systemd/nona-demo-reset.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Wipe and reseed the Nona demo
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/opt/nona/demo/reset.sh
+# Container restart plus ~60 API calls; ceiling so a bad night fails, not hangs.
+TimeoutStartSec=900

--- a/deploy/demo/systemd/nona-demo-reset.timer
+++ b/deploy/demo/systemd/nona-demo-reset.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Nightly reset of the Nona demo
+
+[Timer]
+# Local time; startup-script pins the VM to Asia/Jerusalem, so DST tracks.
+OnCalendar=*-*-* 00:00:00
+Persistent=true
+RandomizedDelaySec=120
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Add a public demo at demo.nonaconfig.com

Stands up a live Nona instance anyone can click into from the README, and adds the deployment tooling that runs it.

**No product code changes.** Everything here lives in `deploy/demo/` and drives Nona through its existing public HTTP API. The seed script works because `/auth/register` creates the first admin and refuses thereafter — exactly the state a freshly wiped database is in. Nothing demo-specific ships in the container, and there is no `Demo:Enabled` flag to leak into a real deployment.

### What a visitor gets

Landing on the site signs them in automatically as an administrator — no account, no install.

Two seeded projects (`acme-storefront`, `mobile-app`) across three environments, covering all four value types, scoped keys, and five releases with real history. Production is pinned to an active release, Staging has one published but not activated, and Development runs on working parameters — the three states side by side.

Everything resets at 00:00 Asia/Jerusalem via a systemd timer that drops the SQLite volume and reseeds. A genuine clean slate, not a best-effort delete.

### Infrastructure

A single `e2-micro` on GCP behind Caddy for automatic TLS. **~$3/month**, all of it the static IPv4 — the VM and its 30 GB disk fall in the always-free tier. Measured usage is ~82 MB across both containers.

Caddy intercepts only the exact path `/` to serve the auto-login page; `/projects`, `/login` and `/api/...` proxy straight through to Nona.

| File | Role |
|---|---|
| `deploy.sh` | Creates the VM, IP and firewall rule, then installs the demo layer |
| `startup-script.sh` | VM bootstrap — re-runs on every boot, lives in instance metadata |
| `install-demo.sh` | Pushes seed/reset/page edits to the VM |
| `seed.sh` | Builds the demo workspace through the admin API |
| `reset.sh` | Drops the database and reseeds |
| `demo-login.html` | Landing page that signs visitors in |
| `systemd/` | Nightly reset timer |

### Credentials

No working credential is committed. `install-demo.sh` generates the demo password with `openssl rand` on the VM on first install and substitutes it into the page; git holds only `demo.env.example` with an email address.

The generated value is public by design — the page ships it to every visitor — which is acceptable on an instance that holds nothing real and resets nightly. `demo.env` and `demo-info.json` are gitignored.

### README

Adds a live-demo badge, a short callout under the feature bullets, and one line at the top of Quick Start for people deciding whether to install.

### Reviewer notes

- `demo-login.html` writes the `auth_token` / `auth_session` keys that `admin/src/entities/auth/model/store.ts` reads. That coupling is deliberate — it is the price of keeping demo code out of the product — and it is confined to that one file. If those keys are ever renamed, the page degrades to a manual sign-in screen rather than breaking outright.
- The demo tracks `rywaredev/nona:latest`, but the nightly reset does not pull, so image updates are currently manual.
- `deploy.sh` defaults to project `ryware` and `michael@ryware.dev`. Worth making these required flags if that matters for a public repo.
