### PR TITLE
feat: add OpenFeature web provider for JavaScript

### DIFF
--- a/.github/workflows/client-sdk-release.yml
+++ b/.github/workflows/client-sdk-release.yml
@@ -66,12 +66,39 @@ jobs:
       - name: Test
         run: npm test --prefix client/javascript-openfeature-provider
 
+  test-javascript-openfeature-web:
+    name: Test JavaScript OpenFeature web provider
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: |
+            client/javascript/package-lock.json
+            client/javascript-openfeature-web-provider/package-lock.json
+
+      - name: Install JavaScript SDK dependencies
+        run: npm ci --prefix client/javascript
+
+      - name: Install OpenFeature web provider dependencies
+        run: npm ci --prefix client/javascript-openfeature-web-provider
+
+      - name: Test
+        run: npm test --prefix client/javascript-openfeature-web-provider
+
   publish-javascript-npm:
     name: Publish JavaScript SDK to npm
     runs-on: ubuntu-latest
     needs:
       - test-javascript
       - test-javascript-openfeature
+      - test-javascript-openfeature-web
     permissions:
       contents: read
       id-token: write
@@ -118,6 +145,7 @@ jobs:
     needs:
       - test-javascript
       - test-javascript-openfeature
+      - test-javascript-openfeature-web
     permissions:
       contents: read
       id-token: write
@@ -158,6 +186,58 @@ jobs:
       - name: Publish JavaScript OpenFeature provider
         run: npm publish --access public --provenance
         working-directory: client/javascript-openfeature-provider
+
+  publish-javascript-openfeature-web-npm:
+    name: Publish JavaScript OpenFeature web provider to npm
+    runs-on: ubuntu-latest
+    needs:
+      - test-javascript
+      - test-javascript-openfeature
+      - test-javascript-openfeature-web
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          cache: npm
+          cache-dependency-path: client/javascript-openfeature-web-provider/package-lock.json
+
+      - name: Resolve package version
+        id: version
+        shell: bash
+        run: |
+          version="${{ inputs.package_version }}"
+          if [ -z "$version" ] && [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            version="${GITHUB_REF_NAME#client-v}"
+          fi
+          echo "value=$version" >> "$GITHUB_OUTPUT"
+
+      # The web provider builds nona-client from source via its file: dependency.
+      - name: Install JavaScript SDK dependencies
+        run: npm ci --prefix client/javascript
+
+      - name: Install OpenFeature web provider dependencies
+        run: npm ci --prefix client/javascript-openfeature-web-provider
+
+      - name: Set package versions
+        if: steps.version.outputs.value != ''
+        shell: bash
+        run: |
+          version="${{ steps.version.outputs.value }}"
+          npm --prefix client/javascript-openfeature-web-provider version "$version" --no-git-tag-version --allow-same-version
+          npm --prefix client/javascript-openfeature-web-provider pkg set "peerDependencies.nona-client=^$version"
+
+      - name: Publish JavaScript OpenFeature web provider
+        run: npm publish --access public --provenance
+        working-directory: client/javascript-openfeature-web-provider
 
   publish-nuget:
     name: Test and publish .NET packages to NuGet

--- a/README.md
+++ b/README.md
@@ -168,6 +168,16 @@ See [client/javascript-openfeature-provider/README.md](client/javascript-openfea
 
 ---
 
+### OpenFeature / JavaScript in the browser
+
+```bash
+npm install nona-client nona-openfeature-web-provider @openfeature/web-sdk
+```
+
+Loads the environment's frontend-scoped config as one snapshot and evaluates synchronously, which is what the OpenFeature web SDK expects. Requires a frontend-scoped API key. See [client/javascript-openfeature-web-provider/README.md](client/javascript-openfeature-web-provider/README.md) for setup and usage.
+
+---
+
 ### Any language (plain HTTP)
 
 No SDK needed. A single GET request returns one config value from the environment's active release, from its working parameters when no release is active, or from a pinned release version:

--- a/client/javascript-openfeature-web-provider/README.md
+++ b/client/javascript-openfeature-web-provider/README.md
@@ -1,0 +1,92 @@
+# nona-openfeature-web-provider
+
+OpenFeature **web** provider for **Nona**. Use Nona remote config and feature flags in the browser through the OpenFeature web SDK.
+
+For Node.js and other backends, use [`nona-openfeature-provider`](../javascript-openfeature-provider) instead. The two packages exist because OpenFeature has two paradigms: the server SDK evaluates per request with a dynamic context, while the web SDK evaluates synchronously against a static context.
+
+## Install
+
+```bash
+npm install nona-client nona-openfeature-web-provider @openfeature/web-sdk
+```
+
+## Usage
+
+```js
+import { OpenFeature } from "@openfeature/web-sdk";
+import { createNonaOpenFeatureWebProvider } from "nona-openfeature-web-provider";
+
+await OpenFeature.setProviderAndWait(
+  createNonaOpenFeatureWebProvider({
+    baseUrl: "https://nona.example.com",
+    apiKey: "your-frontend-api-key",
+    environmentId: "production"
+  })
+);
+
+const client = OpenFeature.getClient();
+
+// Synchronous — the snapshot is already in memory.
+const enabled = client.getBooleanValue("Features:Checkout", false);
+```
+
+You can also hand it an existing Nona client:
+
+```js
+import { createNonaClient } from "nona-client";
+
+const provider = createNonaOpenFeatureWebProvider(createNonaClient({ ... }), {
+  prefix: "Features:"
+});
+```
+
+## Requires a frontend-scoped API key
+
+The provider loads the whole environment as one snapshot, so it uses Nona's client-facing snapshot endpoint (`GET /api/{environmentId}`). That endpoint:
+
+- requires an API key with the **frontend** scope, and
+- returns only **frontend-scoped** config entries.
+
+A backend-only key gets a `404` rather than a `403`, so that a server key cannot be used to enumerate environments. The provider turns both `401` and `404` into a fatal initialization error naming the likely cause, since neither is worth retrying.
+
+Mark the entries you want browsers to see as frontend-scoped in Nona, and make sure the Nona server allows your site's origin via CORS.
+
+## Options
+
+| Option | Default | Description |
+| --- | --- | --- |
+| `prefix` | none | Restrict the snapshot to keys under this prefix, e.g. `Features:`. |
+| `pollIntervalMs` | `30000` | How often to poll for changes. Pass `0` to disable and call `refresh()` yourself. |
+| `metadataName` | `nona` | Name reported as the OpenFeature provider metadata name. |
+| `logger` | none | Receives a message when a background refresh fails. |
+
+Everything `createNonaClient` accepts (`baseUrl`, `apiKey`, `environmentId`, `releaseVersion`, `fetch`, …) is accepted here too when you pass options rather than a client.
+
+## Staying up to date
+
+Polling sends the snapshot's `ETag`, so an unchanged environment costs a `304` and no re-render. When values do change, the provider emits `PROVIDER_CONFIGURATION_CHANGED` with the changed keys, which is what drives re-evaluation in the web SDK and re-renders in the React SDK.
+
+To refresh at a moment of your choosing — after a login, or on `visibilitychange` — call `refresh()`. It returns the keys that changed:
+
+```js
+const changed = await provider.refresh();
+```
+
+## Evaluation context
+
+Nona snapshots are the same for every caller today, so there is no targeting: `onContextChange` refetches the snapshot and the evaluation context is otherwise unused. Setting a context is safe and forward-compatible; it just does not change which values you get yet.
+
+## Error codes
+
+| Situation | Error code |
+| --- | --- |
+| Evaluated before `initialize`, or after `close` | `PROVIDER_NOT_READY` |
+| Key absent from the snapshot (including entries that are not frontend-scoped) | `FLAG_NOT_FOUND` |
+| Value is not a valid boolean or number | `TYPE_MISMATCH` |
+| Value is not valid JSON | `PARSE_ERROR` |
+
+## Test
+
+```bash
+npm test
+```

--- a/client/javascript-openfeature-web-provider/README.md
+++ b/client/javascript-openfeature-web-provider/README.md
@@ -66,6 +66,8 @@ Everything `createNonaClient` accepts (`baseUrl`, `apiKey`, `environmentId`, `re
 
 Polling sends the snapshot's `ETag`, so an unchanged environment costs a `304` and no re-render. When values do change, the provider emits `PROVIDER_CONFIGURATION_CHANGED` with the changed keys, which is what drives re-evaluation in the web SDK and re-renders in the React SDK.
 
+If initialization fails with a temporary network or server error, polling retries at the configured interval. The provider emits `PROVIDER_READY` after a successful retry. With `pollIntervalMs: 0`, call `refresh()` to retry manually. Fatal initialization errors (401 or 404) do not start polling.
+
 To refresh at a moment of your choosing — after a login, or on `visibilitychange` — call `refresh()`. It returns the keys that changed:
 
 ```js

--- a/client/javascript-openfeature-web-provider/package-lock.json
+++ b/client/javascript-openfeature-web-provider/package-lock.json
@@ -1,0 +1,94 @@
+{
+  "name": "nona-openfeature-web-provider",
+  "version": "0.1.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "nona-openfeature-web-provider",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@openfeature/web-sdk": "^1.10.0",
+        "nona-client": "file:../javascript",
+        "typescript": "^5.9.3"
+      },
+      "peerDependencies": {
+        "@openfeature/web-sdk": "^1.10.0",
+        "nona-client": "^0.2.1"
+      }
+    },
+    "../javascript": {
+      "version": "0.2.1",
+      "dev": true,
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "typescript": "^5.9.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@openfeature/core": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/core/-/core-1.12.0.tgz",
+      "integrity": "sha512-7PCPzyd1OC19begz30+CRknFB0ChtyaZUhk7YWrk+Bov1fpVw0HYkTXtoxxsvPfDZB9P9WsT7uixN+Z8f9+bcA==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/@openfeature/web-sdk": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/web-sdk/-/web-sdk-1.10.0.tgz",
+      "integrity": "sha512-qf+JmJSnaslhegNwoDDLn2Cf72P6cIobuAQPUb61MSkzJOZuVLU6f9pv/90FlLcK6UDtp6od//xZHW712rBrmg==",
+      "dev": true,
+      "peerDependencies": {
+        "@openfeature/core": "^1.12.0"
+      }
+    },
+    "node_modules/nona-client": {
+      "resolved": "../javascript",
+      "link": true
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  },
+  "dependencies": {
+    "@openfeature/core": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/core/-/core-1.12.0.tgz",
+      "integrity": "sha512-7PCPzyd1OC19begz30+CRknFB0ChtyaZUhk7YWrk+Bov1fpVw0HYkTXtoxxsvPfDZB9P9WsT7uixN+Z8f9+bcA==",
+      "dev": true,
+      "peer": true
+    },
+    "@openfeature/web-sdk": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@openfeature/web-sdk/-/web-sdk-1.10.0.tgz",
+      "integrity": "sha512-qf+JmJSnaslhegNwoDDLn2Cf72P6cIobuAQPUb61MSkzJOZuVLU6f9pv/90FlLcK6UDtp6od//xZHW712rBrmg==",
+      "dev": true,
+      "requires": {}
+    },
+    "nona-client": {
+      "version": "file:../javascript",
+      "requires": {
+        "typescript": "^5.9.3"
+      }
+    },
+    "typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true
+    }
+  }
+}

--- a/client/javascript-openfeature-web-provider/package.json
+++ b/client/javascript-openfeature-web-provider/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "nona-openfeature-web-provider",
+  "version": "0.1.0",
+  "description": "OpenFeature web provider for Nona — use Nona remote config and feature flags in the browser through the OpenFeature web SDK.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Ryware/nona-config.git",
+    "directory": "client/javascript-openfeature-web-provider"
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "sideEffects": false,
+  "scripts": {
+    "build": "npm --prefix ../javascript run build && tsc -p tsconfig.json",
+    "prepack": "npm run build",
+    "test": "npm run build && node --test test/nona-openfeature-web-provider.test.mjs",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "keywords": [
+    "nona",
+    "openfeature",
+    "open-feature",
+    "provider",
+    "web",
+    "browser",
+    "client-side",
+    "feature-flags",
+    "feature-toggles",
+    "remote-config",
+    "configuration",
+    "config"
+  ],
+  "author": "Nona",
+  "license": "Apache-2.0",
+  "peerDependencies": {
+    "@openfeature/web-sdk": "^1.10.0",
+    "nona-client": "^0.2.1"
+  },
+  "devDependencies": {
+    "@openfeature/web-sdk": "^1.10.0",
+    "nona-client": "file:../javascript",
+    "typescript": "^5.9.3"
+  }
+}

--- a/client/javascript-openfeature-web-provider/src/index.ts
+++ b/client/javascript-openfeature-web-provider/src/index.ts
@@ -1,0 +1,316 @@
+import {
+  ErrorCode,
+  OpenFeatureEventEmitter,
+  ProviderEvents,
+  ProviderFatalError,
+  StandardResolutionReasons,
+  type FlagMetadata,
+  type JsonValue,
+  type Logger,
+  type Provider,
+  type ResolutionDetails,
+} from "@openfeature/web-sdk";
+import {
+  createNonaClient,
+  NonaClientError,
+  type NonaClient,
+  type NonaClientOptions,
+  type NonaConfigValue,
+  type NonaConfigValues,
+} from "nona-client";
+import {
+  parseBooleanValue,
+  parseNumberValue,
+  parseObjectValue,
+  parseStringValue,
+  type ParseResult,
+} from "./value-parsing.js";
+
+const DEFAULT_POLL_INTERVAL_MS = 30_000;
+
+export interface NonaOpenFeatureWebProviderSettings {
+  /** OpenFeature provider metadata name. */
+  metadataName?: string;
+  /** Restrict the snapshot to keys under this prefix, e.g. `Features:`. */
+  prefix?: string;
+  /** Poll interval in ms; `0` disables polling. @default 30000 */
+  pollIntervalMs?: number;
+  /** Reports failed background refreshes, which keep the last good snapshot. */
+  logger?: Logger;
+}
+
+export type NonaOpenFeatureWebProviderOptions = NonaClientOptions &
+  NonaOpenFeatureWebProviderSettings;
+
+export function createNonaOpenFeatureWebProvider(
+  client: NonaClient,
+  settings?: NonaOpenFeatureWebProviderSettings,
+): NonaOpenFeatureWebProvider;
+export function createNonaOpenFeatureWebProvider(
+  options: NonaOpenFeatureWebProviderOptions,
+): NonaOpenFeatureWebProvider;
+export function createNonaOpenFeatureWebProvider(
+  clientOrOptions: NonaClient | NonaOpenFeatureWebProviderOptions,
+  settings: NonaOpenFeatureWebProviderSettings = {},
+): NonaOpenFeatureWebProvider {
+  if (isNonaClient(clientOrOptions)) {
+    return new NonaOpenFeatureWebProvider(clientOrOptions, settings);
+  }
+
+  const { metadataName, prefix, pollIntervalMs, logger, ...clientOptions } =
+    clientOrOptions;
+  return new NonaOpenFeatureWebProvider(createNonaClient(clientOptions), {
+    metadataName,
+    prefix,
+    pollIntervalMs,
+    logger,
+  });
+}
+
+/**
+ * OpenFeature provider for the static-context (client) paradigm: loads the
+ * environment's frontend-scoped config as one snapshot and resolves from
+ * memory, which is what lets the web SDK evaluate synchronously.
+ */
+export class NonaOpenFeatureWebProvider implements Provider {
+  readonly metadata;
+  readonly runsOn = "client" as const;
+  readonly events = new OpenFeatureEventEmitter();
+
+  private values: NonaConfigValues | undefined;
+  private timer: ReturnType<typeof setInterval> | undefined;
+
+  constructor(
+    private readonly client: NonaClient,
+    private readonly settings: NonaOpenFeatureWebProviderSettings = {},
+  ) {
+    this.metadata = { name: settings.metadataName ?? "nona" };
+  }
+
+  async initialize(): Promise<void> {
+    this.values = await this.fetchValues();
+    this.startPolling();
+  }
+
+  /** Snapshots are the same for every caller today, so this is just a refetch. */
+  async onContextChange(): Promise<void> {
+    this.values = await this.fetchValues();
+  }
+
+  /** Refetch, emit `PROVIDER_CONFIGURATION_CHANGED`, return the changed keys. */
+  async refresh(): Promise<string[]> {
+    const next = await this.fetchValues();
+    const previous = this.values;
+    this.values = next;
+
+    const flagsChanged = previous
+      ? changedFlagKeys(previous, next)
+      : Object.keys(next);
+    if (flagsChanged.length > 0) {
+      this.events.emit(ProviderEvents.ConfigurationChanged, { flagsChanged });
+    }
+
+    return flagsChanged;
+  }
+
+  async onClose(): Promise<void> {
+    if (this.timer !== undefined) {
+      clearInterval(this.timer);
+      this.timer = undefined;
+    }
+
+    this.values = undefined;
+  }
+
+  resolveBooleanEvaluation(
+    flagKey: string,
+    defaultValue: boolean,
+  ): ResolutionDetails<boolean> {
+    return this.resolveFlag(flagKey, defaultValue, parseBooleanValue);
+  }
+
+  resolveStringEvaluation(
+    flagKey: string,
+    defaultValue: string,
+  ): ResolutionDetails<string> {
+    return this.resolveFlag(flagKey, defaultValue, parseStringValue);
+  }
+
+  resolveNumberEvaluation(
+    flagKey: string,
+    defaultValue: number,
+  ): ResolutionDetails<number> {
+    return this.resolveFlag(flagKey, defaultValue, parseNumberValue);
+  }
+
+  resolveObjectEvaluation<T extends JsonValue>(
+    flagKey: string,
+    defaultValue: T,
+  ): ResolutionDetails<T> {
+    return this.resolveFlag(flagKey, defaultValue, parseObjectValue<T>);
+  }
+
+  private resolveFlag<T>(
+    flagKey: string,
+    defaultValue: T,
+    parse: (flagKey: string, config: NonaConfigValue) => ParseResult<T>,
+  ): ResolutionDetails<T> {
+    const values = this.values;
+    if (!values) {
+      return error(
+        flagKey,
+        defaultValue,
+        ErrorCode.PROVIDER_NOT_READY,
+        "The Nona web provider has not loaded a config snapshot yet.",
+      );
+    }
+
+    const config = valueAt(values, flagKey);
+    if (!config) {
+      return error(
+        flagKey,
+        defaultValue,
+        ErrorCode.FLAG_NOT_FOUND,
+        `Nona flag '${flagKey}' is not in the '${this.client.environmentId}' snapshot. Client-side evaluation only sees frontend-scoped entries.`,
+      );
+    }
+
+    const parsed = parse(flagKey, config);
+    if (!parsed.ok) {
+      return error(
+        flagKey,
+        defaultValue,
+        parsed.kind === "parse-error"
+          ? ErrorCode.PARSE_ERROR
+          : ErrorCode.TYPE_MISMATCH,
+        parsed.message,
+        config,
+      );
+    }
+
+    return success(flagKey, parsed.value, config);
+  }
+
+  private async fetchValues(): Promise<NonaConfigValues> {
+    try {
+      return await this.client.getAllValues({ prefix: this.settings.prefix });
+    } catch (cause) {
+      throw toSnapshotError(cause);
+    }
+  }
+
+  private startPolling(): void {
+    const interval = this.settings.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+    if (!Number.isFinite(interval) || interval <= 0) {
+      return;
+    }
+
+    this.timer = setInterval(() => {
+      void this.refresh().catch((cause: unknown) => {
+        this.settings.logger?.error(
+          `Nona web provider could not refresh its config snapshot: ${describe(cause)}`,
+        );
+      });
+    }, interval);
+
+    // Do not hold a Node event loop open.
+    (this.timer as unknown as { unref?: () => void }).unref?.();
+  }
+}
+
+/**
+ * 404 is ambiguous on purpose: the snapshot endpoint reports an unknown
+ * environment and a backend-only key identically, so a server key cannot
+ * enumerate environments. Neither it nor 401 is worth retrying.
+ */
+function toSnapshotError(cause: unknown): unknown {
+  if (!(cause instanceof NonaClientError)) {
+    return cause;
+  }
+
+  if (cause.status === 401) {
+    return new ProviderFatalError(
+      `Nona rejected the API key while loading the config snapshot: ${cause.message}`,
+      { cause },
+    );
+  }
+
+  if (cause.status === 404) {
+    return new ProviderFatalError(
+      `Nona could not return a config snapshot: ${cause.message}. Check the environment id, and that the API key is frontend-scoped — the snapshot endpoint is hidden from backend-only keys.`,
+      { cause },
+    );
+  }
+
+  return cause;
+}
+
+function flagMetadata(
+  flagKey: string,
+  config?: NonaConfigValue,
+): FlagMetadata {
+  return config
+    ? { contentType: config.contentType, nonaKey: flagKey }
+    : { nonaKey: flagKey };
+}
+
+/** Flag keys are arbitrary, so `toString` must not resolve off the prototype. */
+function valueAt(
+  values: NonaConfigValues,
+  key: string,
+): NonaConfigValue | undefined {
+  return Object.hasOwn(values, key) ? values[key] : undefined;
+}
+
+function changedFlagKeys(
+  previous: NonaConfigValues,
+  next: NonaConfigValues,
+): string[] {
+  const keys = new Set([...Object.keys(previous), ...Object.keys(next)]);
+  return [...keys].filter((key) => {
+    const before = valueAt(previous, key);
+    const after = valueAt(next, key);
+    return (
+      before?.value !== after?.value ||
+      before?.contentType !== after?.contentType
+    );
+  });
+}
+
+function isNonaClient(
+  value: NonaClient | NonaOpenFeatureWebProviderOptions,
+): value is NonaClient {
+  return "getConfigValue" in value;
+}
+
+function describe(cause: unknown): string {
+  return cause instanceof Error ? cause.message : String(cause);
+}
+
+function success<T>(
+  flagKey: string,
+  value: T,
+  config: NonaConfigValue,
+): ResolutionDetails<T> {
+  return {
+    value,
+    reason: StandardResolutionReasons.STATIC,
+    flagMetadata: flagMetadata(flagKey, config),
+  };
+}
+
+function error<T>(
+  flagKey: string,
+  defaultValue: T,
+  errorCode: ErrorCode,
+  errorMessage: string,
+  config?: NonaConfigValue,
+): ResolutionDetails<T> {
+  return {
+    value: defaultValue,
+    reason: StandardResolutionReasons.ERROR,
+    errorCode,
+    errorMessage,
+    flagMetadata: flagMetadata(flagKey, config),
+  };
+}

--- a/client/javascript-openfeature-web-provider/src/index.ts
+++ b/client/javascript-openfeature-web-provider/src/index.ts
@@ -79,6 +79,8 @@ export class NonaOpenFeatureWebProvider implements Provider {
 
   private values: NonaConfigValues | undefined;
   private timer: ReturnType<typeof setInterval> | undefined;
+  private recovering = false;
+  private closed = false;
 
   constructor(
     private readonly client: NonaClient,
@@ -88,20 +90,44 @@ export class NonaOpenFeatureWebProvider implements Provider {
   }
 
   async initialize(): Promise<void> {
-    this.values = await this.fetchValues();
-    this.startPolling();
+    this.closed = false;
+    try {
+      const values = await this.fetchValues();
+      if (!this.closed) {
+        this.values = values;
+        this.recovering = false;
+        this.startPolling();
+      }
+    } catch (cause) {
+      if (!this.closed && !(cause instanceof ProviderFatalError)) {
+        this.recovering = true;
+        this.startPolling();
+      }
+      throw cause;
+    }
   }
 
   /** Snapshots are the same for every caller today, so this is just a refetch. */
   async onContextChange(): Promise<void> {
-    this.values = await this.fetchValues();
+    const values = await this.fetchValues();
+    if (!this.closed) {
+      this.values = values;
+      this.finishRecovery();
+    }
   }
 
   /** Refetch, emit `PROVIDER_CONFIGURATION_CHANGED`, return the changed keys. */
   async refresh(): Promise<string[]> {
+    if (this.closed) {
+      return [];
+    }
     const next = await this.fetchValues();
+    if (this.closed) {
+      return [];
+    }
     const previous = this.values;
     this.values = next;
+    this.finishRecovery();
 
     const flagsChanged = previous
       ? changedFlagKeys(previous, next)
@@ -114,6 +140,8 @@ export class NonaOpenFeatureWebProvider implements Provider {
   }
 
   async onClose(): Promise<void> {
+    this.closed = true;
+    this.recovering = false;
     if (this.timer !== undefined) {
       clearInterval(this.timer);
       this.timer = undefined;
@@ -199,7 +227,17 @@ export class NonaOpenFeatureWebProvider implements Provider {
     }
   }
 
+  private finishRecovery(): void {
+    if (this.recovering) {
+      this.recovering = false;
+      this.events.emit(ProviderEvents.Ready);
+    }
+  }
+
   private startPolling(): void {
+    if (this.timer !== undefined || this.closed) {
+      return;
+    }
     const interval = this.settings.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
     if (!Number.isFinite(interval) || interval <= 0) {
       return;

--- a/client/javascript-openfeature-web-provider/src/value-parsing.ts
+++ b/client/javascript-openfeature-web-provider/src/value-parsing.ts
@@ -1,0 +1,65 @@
+import type { NonaConfigValue } from "nona-client";
+
+export type ParseFailureKind = "type-mismatch" | "parse-error";
+
+export type ParseResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; kind: ParseFailureKind; message: string };
+
+export function parseBooleanValue(
+  flagKey: string,
+  config: NonaConfigValue,
+): ParseResult<boolean> {
+  const raw = config.value.trim().toLowerCase();
+  if (raw === "true") {
+    return { ok: true, value: true };
+  }
+
+  if (raw === "false") {
+    return { ok: true, value: false };
+  }
+
+  return {
+    ok: false,
+    kind: "type-mismatch",
+    message: `Nona flag '${flagKey}' cannot be evaluated as a boolean.`,
+  };
+}
+
+export function parseStringValue(
+  _flagKey: string,
+  config: NonaConfigValue,
+): ParseResult<string> {
+  return { ok: true, value: config.value };
+}
+
+export function parseNumberValue(
+  flagKey: string,
+  config: NonaConfigValue,
+): ParseResult<number> {
+  const value = Number(config.value);
+  if (config.value.trim() === "" || !Number.isFinite(value)) {
+    return {
+      ok: false,
+      kind: "type-mismatch",
+      message: `Nona flag '${flagKey}' cannot be evaluated as a number.`,
+    };
+  }
+
+  return { ok: true, value };
+}
+
+export function parseObjectValue<T>(
+  flagKey: string,
+  config: NonaConfigValue,
+): ParseResult<T> {
+  try {
+    return { ok: true, value: JSON.parse(config.value) as T };
+  } catch {
+    return {
+      ok: false,
+      kind: "parse-error",
+      message: `Nona flag '${flagKey}' cannot be parsed as JSON.`,
+    };
+  }
+}

--- a/client/javascript-openfeature-web-provider/test/nona-openfeature-web-provider.test.mjs
+++ b/client/javascript-openfeature-web-provider/test/nona-openfeature-web-provider.test.mjs
@@ -1,0 +1,385 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { ErrorCode, OpenFeature, ProviderEvents } from "@openfeature/web-sdk";
+import { createNonaClient } from "nona-client";
+import { jsonResponse } from "../../javascript/test/helpers.mjs";
+import { createNonaOpenFeatureWebProvider } from "../dist/index.js";
+
+const snapshot = {
+  enabled: { value: "true", contentType: "boolean" },
+  limit: { value: "42", contentType: "number" },
+  title: { value: "Checkout", contentType: "text" },
+  settings: { value: '{"color":"green","enabled":true}', contentType: "json" },
+};
+
+function snapshotResponse(values, { etag, status = 200 } = {}) {
+  return new Response(status === 304 ? "" : JSON.stringify(values), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      ...(etag ? { ETag: etag } : {}),
+    },
+  });
+}
+
+function stubClient(handler, options = {}) {
+  const calls = [];
+  const client = createNonaClient("https://nona.test", {
+    environmentId: "production",
+    apiKey: "frontend-key",
+    ...options,
+    fetch: async (url, init) => {
+      calls.push({ url, init });
+      return handler(calls.length, { url, init });
+    },
+  });
+
+  return { client, calls };
+}
+
+function domainFor(name) {
+  return `nona-web-${name}-${Date.now()}`;
+}
+
+test("web provider resolves typed values synchronously from a single snapshot fetch", async () => {
+  const { client, calls } = stubClient(() => snapshotResponse(snapshot));
+  const provider = createNonaOpenFeatureWebProvider(client, {
+    pollIntervalMs: 0,
+  });
+  const domain = domainFor("typed");
+
+  await OpenFeature.setProviderAndWait(domain, provider);
+  const ofClient = OpenFeature.getClient(domain);
+
+  // Synchronous — values, not promises.
+  assert.equal(ofClient.getBooleanValue("enabled", false), true);
+  assert.equal(ofClient.getNumberValue("limit", 0), 42);
+  assert.equal(ofClient.getStringValue("title", "fallback"), "Checkout");
+  assert.deepEqual(ofClient.getObjectValue("settings", {}), {
+    color: "green",
+    enabled: true,
+  });
+
+  assert.equal(calls.length, 1, "evaluation must not hit the network");
+  assert.equal(new URL(calls[0].url).pathname, "/api/production");
+  assert.equal(calls[0].init.headers.get("X-Api-Key"), "frontend-key");
+
+  const details = ofClient.getBooleanDetails("enabled", false);
+  assert.equal(details.reason, "STATIC");
+  assert.equal(details.flagMetadata.contentType, "boolean");
+  assert.equal(details.flagMetadata.nonaKey, "enabled");
+
+  await provider.onClose();
+});
+
+test("web provider sends the snapshot prefix", async () => {
+  const { client, calls } = stubClient(() => snapshotResponse(snapshot));
+  const provider = createNonaOpenFeatureWebProvider(client, {
+    prefix: "Features:",
+    pollIntervalMs: 0,
+  });
+
+  await provider.initialize();
+
+  assert.equal(new URL(calls[0].url).searchParams.get("prefix"), "Features:");
+
+  await provider.onClose();
+});
+
+test("web provider reports missing, mistyped, and unparsable flags", async () => {
+  const { client } = stubClient(() =>
+    snapshotResponse({
+      notABoolean: { value: "yes", contentType: "text" },
+      notANumber: { value: "", contentType: "number" },
+      brokenJson: { value: "{not json", contentType: "json" },
+    }),
+  );
+  const provider = createNonaOpenFeatureWebProvider(client, {
+    pollIntervalMs: 0,
+  });
+  const domain = domainFor("errors");
+
+  await OpenFeature.setProviderAndWait(domain, provider);
+  const ofClient = OpenFeature.getClient(domain);
+
+  const missing = ofClient.getBooleanDetails("missing", true);
+  assert.equal(missing.value, true);
+  assert.equal(missing.errorCode, ErrorCode.FLAG_NOT_FOUND);
+  assert.match(missing.errorMessage, /frontend-scoped/);
+
+  const mistyped = ofClient.getBooleanDetails("notABoolean", false);
+  assert.equal(mistyped.value, false);
+  assert.equal(mistyped.errorCode, ErrorCode.TYPE_MISMATCH);
+
+  const notANumber = ofClient.getNumberDetails("notANumber", 7);
+  assert.equal(notANumber.value, 7);
+  assert.equal(notANumber.errorCode, ErrorCode.TYPE_MISMATCH);
+
+  const broken = ofClient.getObjectDetails("brokenJson", { fallback: true });
+  assert.deepEqual(broken.value, { fallback: true });
+  assert.equal(broken.errorCode, ErrorCode.PARSE_ERROR);
+
+  await provider.onClose();
+});
+
+test("web provider resolves flag keys that collide with object prototype members", async () => {
+  const { client } = stubClient(() =>
+    snapshotResponse({
+      toString: { value: "true", contentType: "boolean" },
+    }),
+  );
+  const provider = createNonaOpenFeatureWebProvider(client, {
+    pollIntervalMs: 0,
+  });
+  const domain = domainFor("prototype");
+
+  await OpenFeature.setProviderAndWait(domain, provider);
+  const ofClient = OpenFeature.getClient(domain);
+
+  assert.equal(ofClient.getBooleanValue("toString", false), true);
+
+  const inherited = ofClient.getBooleanDetails("constructor", false);
+  assert.equal(inherited.value, false);
+  assert.equal(inherited.errorCode, ErrorCode.FLAG_NOT_FOUND);
+
+  await provider.onClose();
+});
+
+test("refresh emits a configuration change for the keys that moved", async () => {
+  const responses = [
+    () => snapshotResponse(snapshot, { etag: 'W/"1"' }),
+    () =>
+      snapshotResponse(
+        {
+          ...snapshot,
+          enabled: { value: "false", contentType: "boolean" },
+          added: { value: "new", contentType: "text" },
+          title: undefined,
+        },
+        { etag: 'W/"2"' },
+      ),
+  ];
+  const { client } = stubClient((call) => {
+    const next = responses[call - 1] ?? responses[responses.length - 1];
+    return next();
+  });
+  const provider = createNonaOpenFeatureWebProvider(client, {
+    pollIntervalMs: 0,
+  });
+
+  const events = [];
+  provider.events.addHandler(ProviderEvents.ConfigurationChanged, (details) => {
+    events.push(details);
+  });
+
+  await provider.initialize();
+  const changed = await provider.refresh();
+
+  assert.deepEqual(changed.sort(), ["added", "enabled", "title"]);
+  assert.equal(events.length, 1);
+  assert.deepEqual([...events[0].flagsChanged].sort(), [
+    "added",
+    "enabled",
+    "title",
+  ]);
+
+  await provider.onClose();
+});
+
+test("refresh over an unchanged snapshot emits nothing", async () => {
+  const { client, calls } = stubClient((call, { init }) => {
+    if (call === 1) {
+      return snapshotResponse(snapshot, { etag: 'W/"1"' });
+    }
+
+    assert.equal(init.headers.get("If-None-Match"), 'W/"1"');
+    return snapshotResponse(undefined, { status: 304, etag: 'W/"1"' });
+  });
+  const provider = createNonaOpenFeatureWebProvider(client, {
+    pollIntervalMs: 0,
+  });
+
+  const events = [];
+  provider.events.addHandler(ProviderEvents.ConfigurationChanged, (details) => {
+    events.push(details);
+  });
+
+  await provider.initialize();
+  const changed = await provider.refresh();
+
+  assert.equal(calls.length, 2);
+  assert.deepEqual(changed, []);
+  assert.deepEqual(events, []);
+
+  await provider.onClose();
+});
+
+test("a backend-only key or unknown environment fails initialization fatally", async () => {
+  const provider = createNonaOpenFeatureWebProvider({
+    baseUrl: "https://nona.test",
+    apiKey: "backend-key",
+    environmentId: "production",
+    pollIntervalMs: 0,
+    fetch: async () => jsonResponse({ error: "Environment not found" }, 404),
+  });
+
+  await assert.rejects(() => provider.initialize(), (thrown) => {
+    assert.equal(thrown.code, ErrorCode.PROVIDER_FATAL);
+    assert.match(thrown.message, /frontend-scoped/);
+    return true;
+  });
+
+  await provider.onClose();
+});
+
+test("a rejected API key fails initialization fatally", async () => {
+  const provider = createNonaOpenFeatureWebProvider({
+    baseUrl: "https://nona.test",
+    apiKey: "nope",
+    environmentId: "production",
+    pollIntervalMs: 0,
+    fetch: async () => jsonResponse({ error: "Invalid API key" }, 401),
+  });
+
+  await assert.rejects(() => provider.initialize(), (thrown) => {
+    assert.equal(thrown.code, ErrorCode.PROVIDER_FATAL);
+    assert.match(thrown.message, /Invalid API key/);
+    return true;
+  });
+});
+
+test("a transient failure stays retryable rather than fatal", async () => {
+  const provider = createNonaOpenFeatureWebProvider({
+    baseUrl: "https://nona.test",
+    apiKey: "frontend-key",
+    environmentId: "production",
+    pollIntervalMs: 0,
+    fetch: async () => jsonResponse({ error: "Server error" }, 503),
+  });
+
+  await assert.rejects(() => provider.initialize(), (thrown) => {
+    assert.equal(thrown.code, undefined);
+    assert.equal(thrown.status, 503);
+    return true;
+  });
+});
+
+test("polling refreshes in the background and stops on close", async () => {
+  let served = 0;
+  const { client, calls } = stubClient(() => {
+    served += 1;
+    return snapshotResponse({
+      enabled: { value: served > 1 ? "false" : "true", contentType: "boolean" },
+    });
+  });
+  const provider = createNonaOpenFeatureWebProvider(client, {
+    pollIntervalMs: 10,
+  });
+  const domain = domainFor("polling");
+
+  const events = [];
+  provider.events.addHandler(ProviderEvents.ConfigurationChanged, (details) => {
+    events.push(details);
+  });
+
+  await OpenFeature.setProviderAndWait(domain, provider);
+  const ofClient = OpenFeature.getClient(domain);
+  assert.equal(ofClient.getBooleanValue("enabled", true), true);
+
+  // The poll timer is unref'd, so wait on one that holds the loop open.
+  await waitFor(() => events.length > 0);
+  assert.deepEqual(events[0].flagsChanged, ["enabled"]);
+  assert.equal(ofClient.getBooleanValue("enabled", true), false);
+
+  await provider.onClose();
+  const afterClose = calls.length;
+  await wait(40);
+  assert.equal(calls.length, afterClose, "close must stop the poll timer");
+});
+
+test("a failed background refresh keeps the last good snapshot", async () => {
+  const logged = [];
+  const { client } = stubClient((call) =>
+    call === 1
+      ? snapshotResponse(snapshot)
+      : jsonResponse({ error: "Server error" }, 503),
+  );
+  const provider = createNonaOpenFeatureWebProvider(client, {
+    pollIntervalMs: 10,
+    logger: {
+      error: (message) => logged.push(message),
+      warn: () => {},
+      info: () => {},
+      debug: () => {},
+    },
+  });
+  const domain = domainFor("resilient");
+
+  await OpenFeature.setProviderAndWait(domain, provider);
+  const ofClient = OpenFeature.getClient(domain);
+
+  await waitFor(() => logged.length > 0);
+
+  assert.equal(ofClient.getBooleanValue("enabled", false), true);
+  assert.match(logged[0], /could not refresh/);
+
+  await provider.onClose();
+});
+
+test("evaluations report not-ready before initialize and after close", async () => {
+  const { client } = stubClient(() => snapshotResponse(snapshot));
+  const provider = createNonaOpenFeatureWebProvider(client, {
+    pollIntervalMs: 0,
+  });
+
+  const before = provider.resolveBooleanEvaluation("enabled", false);
+  assert.equal(before.errorCode, ErrorCode.PROVIDER_NOT_READY);
+
+  await provider.initialize();
+  assert.equal(
+    provider.resolveBooleanEvaluation("enabled", false).value,
+    true,
+  );
+
+  await provider.onClose();
+  const after = provider.resolveBooleanEvaluation("enabled", false);
+  assert.equal(after.errorCode, ErrorCode.PROVIDER_NOT_READY);
+});
+
+test("a context change refetches the snapshot", async () => {
+  const { client, calls } = stubClient((call) =>
+    snapshotResponse({
+      enabled: { value: call === 1 ? "true" : "false", contentType: "boolean" },
+    }),
+  );
+  const provider = createNonaOpenFeatureWebProvider(client, {
+    pollIntervalMs: 0,
+  });
+  const domain = domainFor("context");
+
+  await OpenFeature.setProviderAndWait(domain, provider);
+  const ofClient = OpenFeature.getClient(domain);
+  assert.equal(ofClient.getBooleanValue("enabled", false), true);
+
+  await OpenFeature.setContext(domain, { targetingKey: "user-1" });
+
+  assert.equal(calls.length, 2);
+  assert.equal(ofClient.getBooleanValue("enabled", true), false);
+
+  await provider.onClose();
+});
+
+function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function waitFor(predicate, timeoutMs = 2000) {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() > deadline) {
+      throw new Error("Timed out waiting for a condition.");
+    }
+
+    await wait(5);
+  }
+}

--- a/client/javascript-openfeature-web-provider/test/nona-openfeature-web-provider.test.mjs
+++ b/client/javascript-openfeature-web-provider/test/nona-openfeature-web-provider.test.mjs
@@ -13,7 +13,7 @@ const snapshot = {
 };
 
 function snapshotResponse(values, { etag, status = 200 } = {}) {
-  return new Response(status === 304 ? "" : JSON.stringify(values), {
+  return new Response(status === 304 ? null : JSON.stringify(values), {
     status,
     headers: {
       "Content-Type": "application/json",
@@ -248,7 +248,7 @@ test("a rejected API key fails initialization fatally", async () => {
   });
 });
 
-test("a transient failure stays retryable rather than fatal", async () => {
+test("a transient failure stays retryable rather than fatal", async (t) => {
   const provider = createNonaOpenFeatureWebProvider({
     baseUrl: "https://nona.test",
     apiKey: "frontend-key",
@@ -256,6 +256,7 @@ test("a transient failure stays retryable rather than fatal", async () => {
     pollIntervalMs: 0,
     fetch: async () => jsonResponse({ error: "Server error" }, 503),
   });
+  t.after(() => provider.onClose());
 
   await assert.rejects(() => provider.initialize(), (thrown) => {
     assert.equal(thrown.code, undefined);
@@ -367,6 +368,85 @@ test("a context change refetches the snapshot", async () => {
   assert.equal(ofClient.getBooleanValue("enabled", true), false);
 
   await provider.onClose();
+});
+
+test("polling recovers from failed initialization and continues refreshing", async (t) => {
+  const { client, calls } = stubClient((call) => {
+    if (call <= 2) return jsonResponse({ error: "Unavailable" }, 503);
+    return snapshotResponse({
+      enabled: { value: call === 3 ? "true" : "false", contentType: "boolean" },
+    });
+  });
+  const provider = createNonaOpenFeatureWebProvider(client, { pollIntervalMs: 10 });
+  t.after(() => provider.onClose());
+  const domain = domainFor("init-recovery");
+  const ofClient = OpenFeature.getClient(domain);
+  const readyValues = [];
+  provider.events.addHandler(ProviderEvents.Ready, () => {
+    readyValues.push(ofClient.getBooleanValue("enabled", false));
+  });
+
+  await assert.rejects(OpenFeature.setProviderAndWait(domain, provider));
+  assert.equal(ofClient.providerStatus, "ERROR");
+  await waitFor(() => readyValues.length > 0);
+  assert.equal(ofClient.providerStatus, "READY");
+  assert.deepEqual(readyValues, [true], "snapshot must be available at recovery");
+  await waitFor(() => calls.length >= 4);
+  assert.equal(ofClient.getBooleanValue("enabled", true), false);
+  assert.equal(readyValues.length, 1, "normal refreshes must not emit Ready");
+});
+
+test("disabled polling allows manual recovery without starting a timer", async (t) => {
+  const { client, calls } = stubClient((call) => {
+    if (call === 1) throw new TypeError("Failed to fetch");
+    return snapshotResponse(snapshot);
+  });
+  const provider = createNonaOpenFeatureWebProvider(client, { pollIntervalMs: 0 });
+  t.after(() => provider.onClose());
+  const domain = domainFor("manual-recovery");
+  await assert.rejects(OpenFeature.setProviderAndWait(domain, provider));
+  await wait(40);
+  assert.equal(calls.length, 1);
+
+  await provider.refresh();
+  const ofClient = OpenFeature.getClient(domain);
+  assert.equal(ofClient.providerStatus, "READY");
+  assert.equal(ofClient.getBooleanValue("enabled", false), true);
+  await wait(40);
+  assert.equal(calls.length, 2);
+});
+
+test("fatal initialization failures do not start polling", async (t) => {
+  for (const status of [401, 404]) {
+    const { client, calls } = stubClient(() => jsonResponse({ error: "Rejected" }, status));
+    const provider = createNonaOpenFeatureWebProvider(client, { pollIntervalMs: 10 });
+    t.after(() => provider.onClose());
+    await assert.rejects(provider.initialize(), { code: ErrorCode.PROVIDER_FATAL });
+    await wait(40);
+    assert.equal(calls.length, 1);
+  }
+});
+
+test("closing during a recovery request discards its result and stops retries", async (t) => {
+  let complete;
+  const { client, calls } = stubClient((call) => {
+    if (call === 1) return jsonResponse({ error: "Unavailable" }, 503);
+    return new Promise((resolve) => { complete = resolve; });
+  });
+  const provider = createNonaOpenFeatureWebProvider(client, { pollIntervalMs: 10 });
+  t.after(() => provider.onClose());
+  const events = [];
+  provider.events.addHandler(ProviderEvents.Ready, () => events.push("ready"));
+  provider.events.addHandler(ProviderEvents.ConfigurationChanged, () => events.push("changed"));
+  await assert.rejects(provider.initialize());
+  await waitFor(() => complete !== undefined);
+  await provider.onClose();
+  complete(snapshotResponse(snapshot));
+  await wait(40);
+
+  assert.equal(calls.length, 2);
+  assert.deepEqual(events, []);
+  assert.equal(provider.resolveBooleanEvaluation("enabled", false).errorCode, ErrorCode.PROVIDER_NOT_READY);
 });
 
 function wait(ms) {

--- a/client/javascript-openfeature-web-provider/tsconfig.json
+++ b/client/javascript-openfeature-web-provider/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": [
+      "ES2022",
+      "DOM"
+    ],
+    "rootDir": "src",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/docs/src/content/docs/clients/javascript.md
+++ b/docs/src/content/docs/clients/javascript.md
@@ -5,7 +5,7 @@ description: Read Nona config values and feature flags from JavaScript or TypeSc
 
 Package: `nona-client`
 
-OpenFeature provider package: `nona-openfeature-provider`
+OpenFeature provider packages: `nona-openfeature-provider` (server), `nona-openfeature-web-provider` (browser)
 
 Requirements:
 
@@ -278,6 +278,12 @@ await OpenFeature.setProviderAndWait(domain, createNonaOpenFeatureProvider({
 
 const client = OpenFeature.getClient(domain);
 const enabled = await client.getBooleanValue("Features:Checkout", false);
+```
+
+In the browser, use `nona-openfeature-web-provider` with `@openfeature/web-sdk` instead — OpenFeature's browser paradigm evaluates synchronously from a preloaded snapshot, and needs a frontend-scoped API key:
+
+```bash
+npm install nona-client nona-openfeature-web-provider @openfeature/web-sdk
 ```
 
 If your team thinks in terms of feature flags more than direct config reads, see [OpenFeature](/docs/clients/openfeature).

--- a/docs/src/content/docs/clients/openfeature.md
+++ b/docs/src/content/docs/clients/openfeature.md
@@ -3,7 +3,7 @@ title: OpenFeature
 description: Use Nona through OpenFeature so your application reads flags and config through a standard, vendor-neutral interface with no lock-in.
 ---
 
-Nona ships OpenFeature integration for JavaScript and .NET. Use OpenFeature when you want a standard flag/config interface, less vendor-specific application code, and cleaner portability at the application layer. It is especially useful when your team thinks in feature flags first but still wants access to the same underlying Nona values and scopes.
+Nona ships OpenFeature integration for JavaScript (server and browser) and .NET. Use OpenFeature when you want a standard flag/config interface, less vendor-specific application code, and cleaner portability at the application layer. It is especially useful when your team thinks in feature flags first but still wants access to the same underlying Nona values and scopes.
 
 ## What to set up first
 
@@ -43,7 +43,7 @@ In practice, most teams start with boolean flags such as `Features:Checkout`, th
 
 OpenFeature gives you the application-side abstraction, while Nona still provides the underlying projects, environments, scopes, API keys, history, and rollback. That lets you keep a vendor-neutral read API without giving up a practical self-hosted operations model.
 
-## JavaScript
+## JavaScript (server)
 
 Install the packages:
 
@@ -79,6 +79,56 @@ The provider only needs:
 - environment id
 
 That works because the API key is already bound to one project.
+
+## JavaScript (browser)
+
+OpenFeature has two paradigms, and the browser uses the other one. The server SDK evaluates per request against a dynamic context; the web SDK evaluates **synchronously** against a static context. That needs a different package:
+
+```bash
+npm install nona-client nona-openfeature-web-provider @openfeature/web-sdk
+```
+
+Basic setup:
+
+```js
+import { OpenFeature } from "@openfeature/web-sdk";
+import { createNonaOpenFeatureWebProvider } from "nona-openfeature-web-provider";
+
+await OpenFeature.setProviderAndWait(
+  createNonaOpenFeatureWebProvider({
+    baseUrl: "https://nona.example.com",
+    apiKey: "your-frontend-api-key",
+    environmentId: "production"
+  })
+);
+
+const client = OpenFeature.getClient();
+
+// Synchronous — the snapshot is already in memory.
+const enabled = client.getBooleanValue("Features:Checkout", false);
+```
+
+The web provider loads the whole environment as one snapshot during startup and resolves every flag from memory. Two things follow from that:
+
+- It needs an API key with the **frontend** scope, and it only ever sees **frontend-scoped** parameters. A backend-only key gets a `404`, on purpose, so that a server key cannot be used to enumerate environments. See [Client vs server scope](/docs/concepts/client-vs-server-scope).
+- Your Nona server has to allow the site's origin via CORS.
+
+By default the provider re-checks Nona every 30 seconds, sending the snapshot's `ETag` so an unchanged environment costs a `304`. When values do change it emits `PROVIDER_CONFIGURATION_CHANGED` with the changed keys, which is what triggers re-evaluation in the web SDK and re-renders in the React SDK. Set `pollIntervalMs: 0` to turn polling off and refresh at your own moments instead:
+
+```js
+const changed = await provider.refresh();
+```
+
+Nona snapshots are currently the same for every caller, so there is no targeting yet: setting an evaluation context is safe and forward-compatible, but it only causes a refetch.
+
+### Which JavaScript package?
+
+| | Package | OpenFeature SDK | Evaluation |
+| --- | --- | --- | --- |
+| Node.js, backends | `nona-openfeature-provider` | `@openfeature/server-sdk` | `await` per flag |
+| Browsers | `nona-openfeature-web-provider` | `@openfeature/web-sdk` | synchronous, from a snapshot |
+
+An app that renders on the server and hydrates in the browser uses both — the server provider on the server, the web provider in the browser.
 
 ## .NET
 
@@ -154,6 +204,12 @@ OpenFeature only changes the application-side interface. Nona still provides the
 Usually only if your team already thinks in OpenFeature terms.
 
 Otherwise, many teams start with the direct client or raw HTTP first, then add OpenFeature once the basic read path is proven.
+
+### Can I use OpenFeature in the browser?
+
+Yes, with `nona-openfeature-web-provider` and `@openfeature/web-sdk`.
+
+It is a separate package because OpenFeature's browser paradigm evaluates synchronously against a preloaded snapshot rather than awaiting each flag. It needs a frontend-scoped API key and only sees frontend-scoped parameters.
 
 ### What is the best first OpenFeature test?
 


### PR DESCRIPTION
## This PR

Adds `nona-openfeature-web-provider`, an OpenFeature provider for the browser.

The existing `nona-openfeature-provider` is server-only (`runsOn: "server"`, one awaited fetch per flag). OpenFeature's client paradigm is static-context and **synchronous**, so it needs a separate package against `@openfeature/web-sdk` rather than a flag on the existing one. An SSR app uses both — server provider on the server, this one in the browser.

## How it works

- Loads the environment as one snapshot in `initialize` via `getAllValues()`, then resolves every flag from memory. `resolve*` returns `ResolutionDetails<T>`, not a promise.
- Requires a **frontend-scoped** API key and only sees frontend-scoped entries — that's what `GET /api/{environmentId}` already enforces. No server changes needed.
- Polls every 30s by default, sending the snapshot `ETag`, so an unchanged environment costs a `304` and emits nothing. Real changes emit `PROVIDER_CONFIGURATION_CHANGED` with `flagsChanged`, which drives re-evaluation in the web SDK and re-renders in the React SDK. `pollIntervalMs: 0` disables it in favor of `refresh()`.
- `401` and `404` fail initialization as `ProviderFatalError`. A backend-only key gets a `404` on purpose (so a server key can't enumerate environments), so the message names both likely causes.
- `onContextChange` refetches. There's no targeting yet, so context is otherwise unused; setting one is safe and forward-compatible.
- The poll timer is `unref`'d so it can't hold a Node event loop open during SSR.

## Also in this PR

- **Docs**: `clients/openfeature.md` gains a "JavaScript (browser)" section, a package-picker table, and an FAQ entry; `clients/javascript.md` and the root README point at the new package.
- **CI**: `client-sdk-release.yml` gains matching test and publish jobs. All three publish jobs now gate on all three test jobs.

## Testing

13 tests, `npm test` in `client/javascript-openfeature-web-provider`. Beyond the happy path they cover: only one network call for four evaluations, `304` emitting nothing, the changed-key diff, fatal vs. retryable init failures, a failed background refresh keeping the last good snapshot, and flag keys that collide with `Object.prototype` members.

## Follow-ups

- Value coercion is duplicated with the server provider. It belongs in `nona-client` (it's OpenFeature-agnostic and both depend on it) — worth hoisting before the two drift.
- Once this is published, the [openfeature.dev ecosystem entry](https://github.com/open-feature/openfeature.dev/pull/1475) can get a second JavaScript row with `category: ['Client']`.
