### PR TITLE
docs: Add Kotlin Multiplatform (Android & iOS) client SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ so change whatever you like.
 - [Quick Start](#quick-start)
 - [Repository Layout](#repository-layout)
 - [Client Libraries](#client-libraries)
+  - [JavaScript / Node.js / React Native](#javascript--nodejs--react-native)
+  - [.NET / C#](#net--c)
+  - [Kotlin Multiplatform (Android & iOS)](#kotlin-multiplatform-android--ios)
+  - [OpenFeature / JavaScript](#openfeature--javascript)
+  - [Any language (plain HTTP)](#any-language-plain-http)
+  - [CLI (Windows / macOS / Linux)](#cli-windows--macos--linux)
 - [API](#api)
 - [Docker Compose](#docker-compose)
 - [Migrate from Firebase Remote Config](#migrate-from-firebase-remote-config)
@@ -155,6 +161,52 @@ Console.WriteLine(value.Value);
 ```
 
 📦 [nuget.org/packages/Nona.Client](https://www.nuget.org/packages/Nona.Client)
+
+---
+
+### Kotlin Multiplatform (Android & iOS)
+
+A community-maintained Kotlin Multiplatform SDK for Android and iOS replicating Firebase Remote Config capabilities (in-app defaults, ETags fetching, local caching, and fetch/activation lifecycle).
+
+#### Gradle (Android / KMP)
+
+```kotlin
+dependencies {
+    implementation("io.github.rfaturriza:nona-config:1.0.1")
+}
+```
+
+```kotlin
+val nonaConfig = NonaConfig.instance
+nonaConfig.initialize(
+    apiKey = "your-api-key",
+    environmentId = "production",
+    baseUrl = "https://nona.example.com"
+)
+
+coroutineScope.launch {
+    nonaConfig.fetchAndActivate()
+    val value = nonaConfig.getString("Features:Checkout")
+}
+```
+
+📦 [central.sonatype.com/artifact/io.github.rfaturriza/nona-config](https://central.sonatype.com/artifact/io.github.rfaturriza/nona-config) · 🐙 [NonaConfigKMP on GitHub](https://github.com/rfaturriza/NonaConfigKMP)
+
+#### Swift Package Manager (iOS)
+
+Add `https://github.com/rfaturriza/NonaConfigKMP` via Xcode or `Package.swift`:
+
+```swift
+import NonaConfig
+
+let client = NonaConfigClient.companion.instance
+client.initialize(apiKey: "your-api-key", environmentId: "production", baseUrl: "https://nona.example.com")
+
+Task {
+    let success = try await client.fetchAndActivate()
+    let value = client.getString(key: "Features:Checkout")
+}
+```
 
 ---
 

--- a/docs/src/content/docs/clients/index.md
+++ b/docs/src/content/docs/clients/index.md
@@ -12,6 +12,7 @@ The right one depends on how much abstraction your application needs and what ru
 - [HTTP](/docs/clients/http) for the smallest raw request path
 - [JavaScript](/docs/clients/javascript) for Node.js, TypeScript, and related environments
 - [.NET](/docs/clients/dotnet) for C# services and applications
+- [Kotlin Multiplatform](/docs/clients/kotlin-kmp) for Android and iOS mobile applications
 - [OpenFeature](/docs/clients/openfeature) for a vendor-neutral feature-flag interface
 
 ## What to set up first
@@ -61,6 +62,12 @@ Choose [.NET](/docs/clients/dotnet) when:
 - your application is in C#
 - you want typed JSON reads
 - you want built-in cache behavior
+
+Choose [Kotlin Multiplatform](/docs/clients/kotlin-kmp) when:
+
+- your application is native Android (Kotlin) or iOS (Swift)
+- you want in-app defaults and Firebase Remote Config-style fetch and activate flow
+- you want automatic ETag-based caching and local persistence
 
 Choose [OpenFeature](/docs/clients/openfeature) when:
 

--- a/docs/src/content/docs/clients/kotlin-kmp.md
+++ b/docs/src/content/docs/clients/kotlin-kmp.md
@@ -1,0 +1,183 @@
+---
+title: Kotlin Multiplatform client (Android & iOS)
+description: Read Nona config values and feature flags from Android (Kotlin) and iOS (Swift) using the community NonaConfigKMP SDK, with in-app defaults and fetch/activation lifecycle.
+---
+
+Repository: [`rfaturriza/NonaConfigKMP`](https://github.com/rfaturriza/NonaConfigKMP)
+
+Maven Central package: `io.github.rfaturriza:nona-config`
+
+Swift Package Manager: `https://github.com/rfaturriza/NonaConfigKMP`
+
+Targets:
+
+- Android (API level 21+)
+- iOS (iOS 13+)
+- Kotlin Multiplatform (`commonMain`)
+
+The Kotlin Multiplatform client is a good fit for:
+
+- Native Android apps (Kotlin / Compose)
+- Native iOS apps (Swift / SwiftUI)
+- Kotlin Multiplatform shared modules
+- Apps migrating from Firebase Remote Config requiring `fetchAndActivate()` semantics
+
+## Install
+
+### Gradle (Android / KMP)
+
+Add the dependency to your `build.gradle.kts`:
+
+```kotlin
+dependencies {
+    implementation("io.github.rfaturriza:nona-config:1.0.1")
+}
+```
+
+### Swift Package Manager (iOS)
+
+Add `https://github.com/rfaturriza/NonaConfigKMP` via Xcode **File > Add Package Dependencies...** or in your `Package.swift`:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/rfaturriza/NonaConfigKMP", from: "1.0.1")
+]
+```
+
+## Prepare the value in admin
+
+Before wiring the mobile app:
+
+1. open `Projects` in admin UI
+2. create or select your project
+3. select the target environment such as `production`
+4. create parameters or feature flags
+5. publish a release and set it active
+6. create an API key in `API Keys` with `client` scope
+
+## Basic Initialization
+
+### Kotlin (Android / KMP)
+
+```kotlin
+import com.nonaconfig.NonaConfig
+
+val nonaConfig = NonaConfig.instance
+nonaConfig.initialize(
+    apiKey = "your-api-key",
+    environmentId = "production",
+    baseUrl = "https://nona.example.com"
+)
+```
+
+### Swift (iOS)
+
+In Swift, the companion instance is exposed as `NonaConfigClient`:
+
+```swift
+import NonaConfig
+
+let client = NonaConfigClient.companion.instance
+client.initialize(
+    apiKey: "your-api-key",
+    environmentId: "production",
+    baseUrl: "https://nona.example.com"
+)
+```
+
+## Setting In-App Defaults
+
+Define fallback values locally before fetching remote configuration:
+
+### Kotlin
+
+```kotlin
+nonaConfig.setDefaults(mapOf(
+    "welcome_message" to "Hello!",
+    "feature_enabled" to true
+))
+```
+
+### Swift
+
+```swift
+client.setDefaults(defaults: [
+    "welcome_message": "Hello Swift!",
+    "feature_enabled": true
+])
+```
+
+## Fetching and Activating
+
+The SDK decouples remote network fetching from applying values to the active in-memory state:
+
+### Kotlin
+
+```kotlin
+coroutineScope.launch {
+    val updated = nonaConfig.fetchAndActivate()
+    if (updated) {
+        println("New remote values fetched and activated!")
+    }
+}
+```
+
+### Swift
+
+```swift
+Task {
+    do {
+        let updated = try await client.fetchAndActivate()
+        if updated {
+            print("New remote values fetched and activated!")
+        }
+    } catch {
+        print("Fetch failed: \(error)")
+    }
+}
+```
+
+## Retrieving Values
+
+### Kotlin
+
+```kotlin
+val message = nonaConfig.getString("welcome_message")
+val isEnabled = nonaConfig.getBoolean("feature_enabled")
+val count = nonaConfig.getLong("max_items")
+```
+
+### Swift
+
+```swift
+let message = client.getString(key: "welcome_message")
+let isEnabled = client.getBoolean(key: "feature_enabled")
+```
+
+## Advanced Settings
+
+Customize minimum fetch intervals and release pinning:
+
+```kotlin
+val settings = NonaConfigSettings.Builder()
+    .setBaseUrl("https://nona.example.com")
+    .setMinimumFetchInterval(1.hours)
+    .setReleaseVersion("1.1.x")
+    .build()
+
+nonaConfig.setConfigSettings(settings)
+```
+
+## Features & Architecture
+
+- **ETag support:** Uses HTTP ETags so fetch requests only download changed payloads.
+- **Local persistence:** Values are stored locally to ensure instant app startup.
+- **Decoupled activation:** Allows deferred UI updates to avoid jarring mid-session layout shifts.
+
+## When to use this client
+
+Use `NonaConfigKMP` when:
+
+- Building mobile applications targeting Android, iOS, or KMP.
+- Migrating from Firebase Remote Config and wanting a familiar API.
+- Needing in-app default fallbacks and ETag-backed bandwidth optimization.

--- a/docs/src/content/docs/index.md
+++ b/docs/src/content/docs/index.md
@@ -43,7 +43,7 @@ If you want the shortest route to a working setup:
 3. [Add your first parameter](/docs/get-started/first-parameter)
 4. [Create an API key](/docs/get-started/api-keys)
 5. [Fetch your first config value](/docs/get-started/first-api-call)
-6. Continue with [HTTP client](/docs/clients/http), [JavaScript client](/docs/clients/javascript), or [.NET client](/docs/clients/dotnet)
+6. Continue with [HTTP client](/docs/clients/http), [JavaScript client](/docs/clients/javascript), [.NET client](/docs/clients/dotnet), or [Kotlin Multiplatform client](/docs/clients/kotlin-kmp)
 
 ## What you can do with Nona
 
@@ -104,6 +104,7 @@ Use the smallest integration path that fits your app:
 - [HTTP](/docs/clients/http) for direct reads without an SDK
 - [JavaScript](/docs/clients/javascript) for Node.js and TypeScript apps
 - [.NET](/docs/clients/dotnet) for C# services and applications
+- [Kotlin Multiplatform](/docs/clients/kotlin-kmp) for Android and iOS mobile applications
 - [OpenFeature](/docs/clients/openfeature) if you want a vendor-neutral application interface
 - [CLI](/docs/cli) for admin workflows and migration work
 


### PR DESCRIPTION
### Summary
Adds the community Kotlin Multiplatform (Android & iOS) Client SDK ([NonaConfigKMP](https://github.com/rfaturriza/NonaConfigKMP)) to the **Client Libraries** section in `README.md` and the web documentation site (`docs/src/content/docs/clients/kotlin-kmp.md`).

### Details
- **SDK Repository:** https://github.com/rfaturriza/NonaConfigKMP
- **Maven Central:** `io.github.rfaturriza:nona-config:1.0.1`
- **Swift Package Manager:** Compatible with SPM for iOS targets
- **License:** Apache 2.0
- **Features:** Replicates Firebase Remote Config behavior with in-app defaults, ETags fetching, local caching, and fetch/activation lifecycle for both Android (Kotlin) and iOS (Swift).

### Changes Included
- Updated main `README.md` to list Kotlin Multiplatform under Client Libraries & Table of Contents.
- Added dedicated Astro/Starlight documentation page at `docs/src/content/docs/clients/kotlin-kmp.md`.
- Updated `docs/src/content/docs/clients/index.md` and `docs/src/content/docs/index.md` navigation links.
