### PR TITLE
fix: enforce credential lifecycle and session security boundaries

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -9,7 +9,7 @@ script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 root=$(git -C "$script_dir" rev-parse --show-toplevel)
 remote_name=${1:-origin}
 
-tmp_dir=${TMPDIR:-/tmp}/nona-pre-push.$$
+tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/nona-pre-push.XXXXXXXXXX") || exit 1
 refs_file=$tmp_dir/refs
 cs_files_file=$tmp_dir/cs-files
 dotnet_files_file=$tmp_dir/dotnet-files
@@ -19,7 +19,6 @@ cleanup() {
 }
 
 trap cleanup EXIT HUP INT TERM
-mkdir -p "$tmp_dir"
 : >"$refs_file"
 : >"$cs_files_file"
 : >"$dotnet_files_file"

--- a/README.md
+++ b/README.md
@@ -303,8 +303,10 @@ docker compose -f primary-replica-prod.yml up -d
 
 | Service | API port | libSQL port | gRPC port |
 |---------|----------|-------------|-----------|
-| `nona-primary` | `18081` | `19080` | `15001` |
-| `nona-replica` | `18082` | `19082` | — |
+| `nona-primary` | `18081` | internal only | internal only |
+| `nona-replica` | `18082` | internal only | — |
+
+The replication compose files publish only the Nona API. SQL HTTP and replication gRPC stay on the private container network; Nona authentication does not protect these database listeners.
 
 The replica connects to the primary over gRPC and syncs automatically.
 

--- a/admin/src/__tests__/integration/AccountPage.test.tsx
+++ b/admin/src/__tests__/integration/AccountPage.test.tsx
@@ -105,7 +105,7 @@ describe('AccountPage', () => {
     expect(await screen.findByRole('alert')).toHaveTextContent(/at least 8 characters/i);
   });
 
-  it('changes the password, clears the form, and keeps the session', async () => {
+  it('changes the password, clears the form, and clears the session', async () => {
     renderPage();
 
     const current = await screen.findByLabelText(/current password/i) as HTMLInputElement;
@@ -120,6 +120,7 @@ describe('AccountPage', () => {
     expect(current.value).toBe('');
     expect(next.value).toBe('');
     expect(confirm.value).toBe('');
-    expect(localStorage.getItem('auth_token')).toBe(mockToken);
+    expect(localStorage.getItem('auth_token')).toBeNull();
+    expect(sessionStorage.getItem('auth_token')).toBeNull();
   });
 });

--- a/admin/src/__tests__/integration/CliLoginPage.test.tsx
+++ b/admin/src/__tests__/integration/CliLoginPage.test.tsx
@@ -1,17 +1,17 @@
-import { Route, Router } from '@solidjs/router';
-import { MetaProvider } from '@solidjs/meta';
-import { QueryClient, QueryClientProvider } from '@tanstack/solid-query';
-import { fireEvent, render, screen, waitFor } from '@solidjs/testing-library';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { ToastProvider } from '../../shared/ui/toast';
-import { mockToken } from '../mocks/data';
-import CliLoginPage from '../../pages/auth/CliLoginPage';
-import { ThemeProvider } from '../../shared/hooks/useTheme';
+import { MetaProvider } from "@solidjs/meta";
+import { Route, Router } from "@solidjs/router";
+import { fireEvent, render, screen, waitFor } from "@solidjs/testing-library";
+import { QueryClient, QueryClientProvider } from "@tanstack/solid-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import CliLoginPage from "../../pages/auth/CliLoginPage";
+import { ThemeProvider } from "../../shared/hooks/useTheme";
+import { ToastProvider } from "../../shared/ui/toast";
+import { mockToken } from "../mocks/data";
 
 function renderCliLogin(path: string) {
-  window.history.pushState({}, '', path);
+  window.history.pushState({}, "", path);
   const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } }
   });
 
   return render(() => (
@@ -29,62 +29,88 @@ function renderCliLogin(path: string) {
   ));
 }
 
-function cliLoginPath(state = 'state-123', redirect = `${window.location.origin}/callback`) {
+function cliLoginPath(state = "state-123", redirect = `${window.location.origin}/callback`) {
   return `/cli-login?cli_state=${encodeURIComponent(state)}&cli_redirect=${encodeURIComponent(redirect)}`;
 }
 
-describe('CliLoginPage', () => {
+describe("CliLoginPage", () => {
   beforeEach(() => {
     localStorage.clear();
     sessionStorage.clear();
     vi.restoreAllMocks();
-    window.history.pushState({}, '', '/');
+    window.history.pushState({}, "", "/");
   });
 
-  it('redirects authenticated users to the CLI callback', async () => {
-    localStorage.setItem('auth_token', mockToken);
+  it("requires consent before exporting an authenticated session", async () => {
+    localStorage.setItem("auth_token", mockToken);
     localStorage.setItem(
-      'auth_session',
-      JSON.stringify({ email: 'admin@example.com', role: 'admin' }),
+      "auth_session",
+      JSON.stringify({ email: "admin@example.com", role: "admin" })
     );
 
-    renderCliLogin(cliLoginPath('state-auth'));
+    renderCliLogin(cliLoginPath("state-auth"));
+    const authorize = await screen.findByRole("button", { name: "Authorize CLI" });
+    expect(window.location.pathname).toBe("/cli-login");
+    expect(window.location.search).not.toContain("token=");
+    fireEvent.click(authorize);
 
     await waitFor(() => {
-      expect(window.location.pathname).toBe('/callback');
+      expect(window.location.pathname).toBe("/callback");
     });
 
     const callback = new URL(window.location.href);
-    expect(callback.searchParams.get('token')).toBe(mockToken);
-    expect(callback.searchParams.get('state')).toBe('state-auth');
-    expect(callback.searchParams.get('username')).toBe('admin@example.com');
-    expect(callback.searchParams.get('role')).toBe('admin');
-    expect(callback.searchParams.get('expires_at')).toBeTruthy();
+    expect(callback.searchParams.get("token")).toBe(mockToken);
+    expect(callback.searchParams.get("state")).toBe("state-auth");
+    expect(callback.searchParams.get("username")).toBe("admin@example.com");
+    expect(callback.searchParams.get("role")).toBe("admin");
+    expect(callback.searchParams.get("expires_at")).toBeTruthy();
   });
 
-  it('redirects to the CLI callback after password login', async () => {
-    renderCliLogin(cliLoginPath('state-login'));
+  it("redirects to the CLI callback after password login", async () => {
+    renderCliLogin(cliLoginPath("state-login"));
 
-    fireEvent.input(screen.getByLabelText(/email/i), { target: { value: 'admin@example.com' } });
-    fireEvent.input(screen.getByLabelText(/^password$/i), { target: { value: 'password' } });
-    fireEvent.click(screen.getByRole('button', { name: /login to console/i }));
+    fireEvent.input(screen.getByLabelText(/email/i), { target: { value: "admin@example.com" } });
+    fireEvent.input(screen.getByLabelText(/^password$/i), { target: { value: "password" } });
+    fireEvent.click(screen.getByRole("button", { name: /login to console/i }));
+    const authorize = await screen.findByRole("button", { name: "Authorize CLI" });
+    expect(window.location.pathname).toBe("/cli-login");
+    fireEvent.click(authorize);
 
     await waitFor(() => {
-      expect(window.location.pathname).toBe('/callback');
+      expect(window.location.pathname).toBe("/callback");
     });
 
     const callback = new URL(window.location.href);
-    expect(callback.searchParams.get('token')).toBe(mockToken);
-    expect(callback.searchParams.get('state')).toBe('state-login');
-    expect(callback.searchParams.get('role')).toBe('admin');
-    expect(callback.searchParams.get('expires_at')).toBe('2099-01-01T00:00:00Z');
+    expect(callback.searchParams.get("token")).toBe(mockToken);
+    expect(callback.searchParams.get("state")).toBe("state-login");
+    expect(callback.searchParams.get("role")).toBe("admin");
+    expect(callback.searchParams.get("expires_at")).toBe("2099-01-01T00:00:00Z");
   });
 
-  it('rejects non-loopback CLI callback URLs', async () => {
-    renderCliLogin(cliLoginPath('state-bad', 'https://evil.example/callback'));
+  it("cancels without disclosing a token", async () => {
+    localStorage.setItem("auth_token", mockToken);
+    renderCliLogin(cliLoginPath("cancel"));
+    fireEvent.click(await screen.findByRole("button", { name: "Cancel" }));
+    await waitFor(() => expect(window.location.pathname).toBe("/projects"));
+    expect(window.location.search).not.toContain("token=");
+  });
 
-    expect(await screen.findByTestId('cli-login-error')).toBeInTheDocument();
+  it.each([
+    "http://user@127.0.0.1/callback",
+    "http://127.0.0.1/other",
+    "https://127.0.0.1/callback"
+  ])("rejects invalid callback %s", async redirect => {
+    localStorage.setItem("auth_token", mockToken);
+    renderCliLogin(cliLoginPath("invalid", redirect));
+    expect(await screen.findByTestId("cli-login-error")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Authorize CLI" })).not.toBeInTheDocument();
+  });
+
+  it("rejects non-loopback CLI callback URLs", async () => {
+    renderCliLogin(cliLoginPath("state-bad", "https://evil.example/callback"));
+
+    expect(await screen.findByTestId("cli-login-error")).toBeInTheDocument();
     expect(screen.getByText(/loopback \/callback URL/i)).toBeInTheDocument();
-    expect(window.location.pathname).toBe('/cli-login');
+    expect(window.location.pathname).toBe("/cli-login");
   });
 });

--- a/admin/src/__tests__/unit/stores/auth.store.test.ts
+++ b/admin/src/__tests__/unit/stores/auth.store.test.ts
@@ -1,10 +1,70 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { authStore } from "../../../entities/auth/model/store";
+import { queryClient } from "../../../shared/api/query-client";
 
 describe("authStore", () => {
   beforeEach(() => {
     localStorage.clear();
     sessionStorage.clear();
+  });
+
+  it("clears this tab's cache when another tab changes the remembered identity", async () => {
+    const { vi } = await import("vitest");
+    const reload = vi.spyOn(window.location, "reload").mockImplementation(() => {});
+    try {
+      authStore.saveSession("admin", { email: "admin@example.com", role: "admin" });
+      queryClient.setQueryData(["private"], "admin secret");
+      localStorage.setItem("auth_token", "member");
+      authStore.handleStorageChange(
+        new StorageEvent("storage", {
+          key: "auth_token",
+          oldValue: "admin",
+          newValue: "member",
+          storageArea: localStorage
+        })
+      );
+      expect(queryClient.getQueryData(["private"])).toBeUndefined();
+      expect(authStore.getToken()).toBe("member");
+      expect(reload).toHaveBeenCalledOnce();
+      queryClient.setQueryData(["private"], "cached");
+      authStore.handleStorageChange(
+        new StorageEvent("storage", { key: null, storageArea: localStorage })
+      );
+      expect(queryClient.getQueryData(["private"])).toBeUndefined();
+    } finally {
+      reload.mockRestore();
+    }
+  });
+
+  it("clears cached secrets and both storage tiers when changing identity", () => {
+    authStore.saveSession("admin-token", { email: "admin@example.com", role: "admin" });
+    queryClient.setQueryData(["project", "detail", "private", "config-entries", "production"], {
+      secret: "admin-only"
+    });
+    authStore.clearSession();
+    expect(queryClient.getQueryCache().getAll()).toHaveLength(0);
+    authStore.saveSession("member-token", { email: "member@example.com", role: "member" }, false);
+    expect(authStore.getToken()).toBe("member-token");
+    expect(localStorage.getItem("auth_token")).toBeNull();
+    expect(queryClient.getQueryCache().getAll()).toHaveLength(0);
+  });
+
+  it("does not restore an old session's cache when its pending request completes", async () => {
+    let finish!: (value: string) => void;
+    const pending = queryClient
+      .fetchQuery({
+        queryKey: ["private"],
+        queryFn: () =>
+          new Promise<string>(resolve => {
+            finish = resolve;
+          })
+      })
+      .catch(() => undefined);
+    authStore.saveSession("new-token", { email: "member@example.com", role: "member" }, false);
+    finish("old secret");
+    await pending;
+    expect(queryClient.getQueryData(["private"])).toBeUndefined();
+    expect(queryClient.getQueryCache().getAll()).toHaveLength(0);
   });
 
   it("stores an explicit admin role without an admin flag", () => {
@@ -24,5 +84,55 @@ describe("authStore", () => {
     );
 
     expect(authStore.getSession()).toBeNull();
+  });
+});
+
+describe("responses from a previous identity", () => {
+  it("rejects a late mutation response before it can repopulate caches", async () => {
+    const { ApiClient } = await import("../../../shared/api/client");
+    const { vi } = await import("vitest");
+    authStore.saveSession("old", { email: "admin@example.com", role: "admin" });
+    let complete!: (response: Response) => void;
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(
+      () =>
+        new Promise(resolve => {
+          complete = resolve;
+        })
+    );
+    try {
+      const pending = new ApiClient().put("/admin/private", { value: "old" });
+      authStore.saveSession("new", { email: "member@example.com", role: "member" });
+      complete(new Response(JSON.stringify({ secret: "old response" }), { status: 200 }));
+      await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+      expect(authStore.getToken()).toBe("new");
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("does not sign the new user out when an old request returns 401", async () => {
+    const { ApiClient } = await import("../../../shared/api/client");
+    const { vi } = await import("vitest");
+    authStore.saveSession("old", { email: "admin@example.com", role: "admin" });
+    let complete!: (response: Response) => void;
+    const unauthorized = vi.fn();
+    window.addEventListener("auth:unauthorized", unauthorized);
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(
+      () =>
+        new Promise(resolve => {
+          complete = resolve;
+        })
+    );
+    try {
+      const pending = new ApiClient().get("/admin/private");
+      authStore.clearSession();
+      authStore.saveSession("new", { email: "member@example.com", role: "member" });
+      complete(new Response("{}", { status: 401 }));
+      await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+      expect(unauthorized).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+      window.removeEventListener("auth:unauthorized", unauthorized);
+    }
   });
 });

--- a/admin/src/app/App.tsx
+++ b/admin/src/app/App.tsx
@@ -20,6 +20,7 @@ export default function App(): JSX.Element {
       // Listen for unauthorized events dispatched by the API client.
       // Using a custom event keeps shared/api/client.ts free of entity-layer imports.
       createEventListener(window, "auth:unauthorized", () => authStore.handleUnauthorized());
+      createEventListener(window, "storage", event => authStore.handleStorageChange(event));
     }
   });
 
@@ -85,14 +86,8 @@ export default function App(): JSX.Element {
                     path="/projects"
                     component={lazy(() => import("../pages/projects/ProjectsPage"))}
                   />
-                  <Route
-                    path="/projects/:slug/environments"
-                    component={EnvironmentsSection}
-                  />
-                  <Route
-                    path="/projects/:slug/shared-links"
-                    component={SharedLinksSection}
-                  />
+                  <Route path="/projects/:slug/environments" component={EnvironmentsSection} />
+                  <Route path="/projects/:slug/shared-links" component={SharedLinksSection} />
                   <Route path="/projects/:slug/api-keys" component={ApiKeysSection} />
                   <Route path="/projects/:slug/releases" component={ReleasesSection} />
                   <Route path="/projects/:slug" component={ParametersSection} />
@@ -101,7 +96,10 @@ export default function App(): JSX.Element {
                     component={lazy(() => import("../pages/account/AccountPage"))}
                   />
                   <Route component={AdminRoute}>
-                    <Route path="/users" component={lazy(() => import("../pages/users/UsersPage"))} />
+                    <Route
+                      path="/users"
+                      component={lazy(() => import("../pages/users/UsersPage"))}
+                    />
                     <Route
                       path="/audit-logs"
                       component={lazy(() => import("../pages/audit-logs/AuditLogsPage"))}
@@ -144,7 +142,11 @@ function ProtectedRoute(props: { children?: JSX.Element }) {
 }
 
 function AdminRoute(props: { children?: JSX.Element }) {
-  return <Show when={canManageUsers()} fallback={<AccessDenied />}>{props.children}</Show>;
+  return (
+    <Show when={canManageUsers()} fallback={<AccessDenied />}>
+      {props.children}
+    </Show>
+  );
 }
 
 const AuthLayout = lazy(() =>
@@ -154,7 +156,10 @@ const AuthLayout = lazy(() =>
 // Public route layout (redirect to dashboard if already authenticated)
 function PublicRoute(props: { children?: JSX.Element }) {
   return (
-    <Show when={!authService.isAuthenticated()} fallback={<Navigate href={getActiveProjectHref()} />}>
+    <Show
+      when={!authService.isAuthenticated()}
+      fallback={<Navigate href={getActiveProjectHref()} />}
+    >
       <AuthLayout>{props.children}</AuthLayout>
     </Show>
   );

--- a/admin/src/app/query-client.ts
+++ b/admin/src/app/query-client.ts
@@ -1,18 +1,1 @@
-import { QueryClient } from "@tanstack/solid-query";
-
-/**
- * Singleton QueryClient with project-wide defaults.
- *
- * Design notes:
- * - refetchOnWindowFocus disabled — admin panel state is mutation-driven, not time-based.
- * - retry: 1 — retry once on transient network errors; no more to avoid delayed error UX.
- */
-export const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      refetchOnWindowFocus: false,
-      retry: 1,
-      staleTime: 5 * 60 * 1000,
-    },
-  },
-});
+export { queryClient } from "../shared/api/query-client";

--- a/admin/src/entities/auth/model/store.ts
+++ b/admin/src/entities/auth/model/store.ts
@@ -1,3 +1,5 @@
+import { queryClient } from "../../../shared/api/query-client";
+import { advanceSession } from "../../../shared/api/session";
 import { USER_ROLES, type UserRole } from "./roles";
 
 /**
@@ -14,22 +16,42 @@ export interface AuthSession {
   username?: string;
 }
 
+function clearSessionData() {
+  advanceSession();
+  void queryClient.cancelQueries();
+  queryClient.clear();
+}
+
 export const authStore = {
   /**
    * Persist token and session metadata after a successful login.
    * @param rememberMe - true → localStorage, false → sessionStorage (cleared on tab close)
    */
   saveSession(token: string, session: AuthSession, rememberMe = true): void {
+    this.clearSession();
     const storage = rememberMe ? localStorage : sessionStorage;
     storage.setItem("auth_token", token);
     storage.setItem("auth_session", JSON.stringify(session));
   },
 
   clearSession(): void {
+    // Cancel before clearing so responses from the old session cannot repopulate it.
+    clearSessionData();
     localStorage.removeItem("auth_token");
     sessionStorage.removeItem("auth_token");
     localStorage.removeItem("auth_session");
     sessionStorage.removeItem("auth_session");
+  },
+
+  handleStorageChange(event: StorageEvent): void {
+    if (
+      event.storageArea !== localStorage ||
+      (event.key !== null && event.key !== "auth_token" && event.key !== "auth_session")
+    )
+      return;
+    clearSessionData();
+    // Reload also discards component-local copies without overwriting the other tab's session.
+    window.location.reload();
   },
 
   getToken(): string | null {

--- a/admin/src/pages/account/AccountPage.tsx
+++ b/admin/src/pages/account/AccountPage.tsx
@@ -1,3 +1,5 @@
+import { useNavigate } from "@solidjs/router";
+import { authStore } from "../../entities/auth/model/store";
 import { Title } from "@solidjs/meta";
 import { useMutation, useQuery } from "@tanstack/solid-query";
 import { createSignal, Show } from "solid-js";
@@ -14,6 +16,7 @@ import { PasswordStrengthMeter } from "../../widgets/auth-shell/PasswordStrength
 
 export default function AccountPage() {
   const { addToast } = useToast();
+  const navigate = useNavigate();
   const [currentPassword, setCurrentPassword] = createSignal("");
   const [newPassword, setNewPassword] = createSignal("");
   const [confirmPassword, setConfirmPassword] = createSignal("");
@@ -37,6 +40,8 @@ export default function AccountPage() {
       setConfirmPassword("");
       setError("");
       addToast(MSG.PASSWORD_CHANGED, "success");
+      authStore.clearSession();
+      navigate("/login", { replace: true });
     },
     onError: caught => setError(changePasswordError(caught))
   }));

--- a/admin/src/pages/auth/CliLoginPage.tsx
+++ b/admin/src/pages/auth/CliLoginPage.tsx
@@ -1,5 +1,6 @@
-import { onMount, Show } from "solid-js";
+import { createSignal, onMount, Show } from "solid-js";
 import { authStore } from "../../entities/auth/model/store";
+import { Button } from "../../shared/ui/button";
 import type { LoginResponse } from "../../types";
 import { AuthCard } from "../../widgets/auth-shell/AuthCard";
 import { AuthLayout } from "../../widgets/auth-shell/AuthLayout";
@@ -19,6 +20,7 @@ interface CliLoginCallback {
 
 export default function CliLoginPage() {
   const parsed = parseCliLoginRequest(window.location.search);
+  const [pending, setPending] = createSignal<CliLoginCallback>();
 
   onMount(() => {
     if (!parsed.request || !authStore.isAuthenticated()) return;
@@ -27,7 +29,7 @@ export default function CliLoginPage() {
     if (!token) return;
 
     const session = authStore.getSession();
-    redirectToCliCallback(parsed.request, {
+    setPending({
       token,
       username: session?.username ?? session?.email ?? "",
       role: session?.role ?? "",
@@ -53,11 +55,40 @@ export default function CliLoginPage() {
         </AuthLayout>
       }
     >
-      <Show when={!authStore.isAuthenticated()} fallback={null}>
+      <Show
+        when={!pending()}
+        fallback={
+          <AuthLayout>
+            <AuthCard title="Authorize CLI" headingTestId="cli-authorization-heading">
+              <p class="mb-4">
+                Allow the CLI on this computer to access your Nona account as {pending()?.username}?
+              </p>
+              <p class="mb-4">
+                Callback: {parsed.request?.redirectUrl.origin}. Only continue if you started CLI
+                login yourself.
+              </p>
+              <Button
+                type="button"
+                onClick={() => redirectToCliCallback(parsed.request!, pending()!)}
+              >
+                Authorize CLI
+              </Button>
+              <Button
+                type="button"
+                onClick={() => {
+                  window.location.href = "/projects";
+                }}
+              >
+                Cancel
+              </Button>
+            </AuthCard>
+          </AuthLayout>
+        }
+      >
         <AuthLayout>
           <LoginPage
             onLoginSuccess={(result: LoginResponse) =>
-              redirectToCliCallback(parsed.request!, {
+              setPending({
                 token: result.token,
                 username: result.username ?? "",
                 role: result.role,

--- a/admin/src/shared/api/client.ts
+++ b/admin/src/shared/api/client.ts
@@ -1,3 +1,5 @@
+import { captureSession, sessionToken } from "./session";
+
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || window.location.origin;
 
 const ALLOW_401_ENDPOINTS = [
@@ -5,7 +7,7 @@ const ALLOW_401_ENDPOINTS = [
   "/auth/first-time",
   "/auth/sso/google",
   "/auth/sso/microsoft",
-  "/auth/sso/config",
+  "/auth/sso/config"
 ];
 
 function isAllowlisted401Endpoint(endpoint: string) {
@@ -37,7 +39,9 @@ function getValidationErrorMessage(payload: unknown): string | undefined {
     .flatMap(([field, values]) =>
       Array.isArray(values)
         ? values
-            .filter((value): value is string => typeof value === "string" && value.trim().length > 0)
+            .filter(
+              (value): value is string => typeof value === "string" && value.trim().length > 0
+            )
             .map(value => `${field}: ${value}`)
         : []
     );
@@ -53,18 +57,24 @@ function getErrorMessage(payload: unknown): string {
 
   const error = payload as Record<string, unknown>;
   const fallbackFields = [error.detail, error.error, error.message, error.title];
-  return fallbackFields.find(
-    (value): value is string => typeof value === "string" && value.trim().length > 0
-  ) ?? "Request failed";
+  return (
+    fallbackFields.find(
+      (value): value is string => typeof value === "string" && value.trim().length > 0
+    ) ?? "Request failed"
+  );
 }
 
 export class ApiClient {
   private getAuthHeader(): HeadersInit {
-    const token = localStorage.getItem("auth_token") || sessionStorage.getItem("auth_token");
+    const token = sessionToken();
     return token ? { Authorization: `Bearer ${token}` } : {};
   }
 
-  private async send(endpoint: string, options: RequestInit = {}): Promise<Response> {
+  private async send(
+    endpoint: string,
+    options: RequestInit,
+    assertSession: () => void
+  ): Promise<Response> {
     const url = `${API_BASE_URL}${endpoint}`;
 
     const response = await fetch(url, {
@@ -72,10 +82,11 @@ export class ApiClient {
       headers: {
         "Content-Type": "application/json",
         ...this.getAuthHeader(),
-        ...options.headers,
-      },
+        ...options.headers
+      }
     });
 
+    assertSession();
     if (!response.ok) {
       if (response.status === 401 && !isAllowlisted401Endpoint(endpoint)) {
         // Signal the auth store to clear the session and redirect.
@@ -83,37 +94,39 @@ export class ApiClient {
         window.dispatchEvent(new CustomEvent("auth:unauthorized"));
       }
 
-      const error = await response
-        .json()
-        .catch(() => ({ detail: "An error occurred" }));
-      throw new ApiRequestError(
-        getErrorMessage(error),
-        error.errorCode,
-      );
+      const error = await response.json().catch(() => ({ detail: "An error occurred" }));
+      assertSession();
+      throw new ApiRequestError(getErrorMessage(error), error.errorCode);
     }
 
     return response;
   }
 
   async request<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
-    const response = await this.send(endpoint, options);
+    const assertSession = captureSession();
+    const response = await this.send(endpoint, options, assertSession);
 
     // Handle 204 No Content
     if (response.status === 204) {
       return {} as T;
     }
 
-    return response.json();
+    const data = await response.json();
+    assertSession();
+    return data;
   }
 
   async getBlob(endpoint: string): Promise<{ blob: Blob; fileName?: string }> {
-    const response = await this.send(endpoint, { method: "GET" });
+    const assertSession = captureSession();
+    const response = await this.send(endpoint, { method: "GET" }, assertSession);
     const disposition = response.headers.get("Content-Disposition");
     const encodedFileName = disposition?.match(/filename\*?=(?:UTF-8''|")?([^";]+)/i)?.[1];
 
+    const blob = await response.blob();
+    assertSession();
     return {
-      blob: await response.blob(),
-      fileName: encodedFileName ? decodeURIComponent(encodedFileName) : undefined,
+      blob,
+      fileName: encodedFileName ? decodeURIComponent(encodedFileName) : undefined
     };
   }
 
@@ -124,14 +137,14 @@ export class ApiClient {
   async post<T>(endpoint: string, data?: unknown): Promise<T> {
     return this.request<T>(endpoint, {
       method: "POST",
-      body: data ? JSON.stringify(data) : undefined,
+      body: data ? JSON.stringify(data) : undefined
     });
   }
 
   async put<T>(endpoint: string, data?: unknown): Promise<T> {
     return this.request<T>(endpoint, {
       method: "PUT",
-      body: data ? JSON.stringify(data) : undefined,
+      body: data ? JSON.stringify(data) : undefined
     });
   }
 

--- a/admin/src/shared/api/query-client.ts
+++ b/admin/src/shared/api/query-client.ts
@@ -1,0 +1,18 @@
+import { QueryClient } from "@tanstack/solid-query";
+
+/**
+ * Singleton QueryClient with project-wide defaults.
+ *
+ * Design notes:
+ * - refetchOnWindowFocus disabled — admin panel state is mutation-driven, not time-based.
+ * - retry: 1 — retry once on transient network errors; no more to avoid delayed error UX.
+ */
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      retry: 1,
+      staleTime: 5 * 60 * 1000
+    }
+  }
+});

--- a/admin/src/shared/api/session.ts
+++ b/admin/src/shared/api/session.ts
@@ -1,0 +1,17 @@
+// A generation changes even when the same account signs in again.
+let generation = 0;
+export const advanceSession = () => {
+  generation++;
+};
+export const sessionToken = () =>
+  localStorage.getItem("auth_token") || sessionStorage.getItem("auth_token");
+
+export function captureSession() {
+  const started = generation;
+  const token = sessionToken();
+  return () => {
+    if (started !== generation || token !== sessionToken()) {
+      throw new DOMException("The session changed while the request was running.", "AbortError");
+    }
+  };
+}

--- a/core/src/Application/Admin/ApiKeys/Commands/CreateApiKeyCommand.cs
+++ b/core/src/Application/Admin/ApiKeys/Commands/CreateApiKeyCommand.cs
@@ -36,10 +36,11 @@ public class CreateApiKeyCommandHandler(
             return new CreateApiKeyResult(false, null, "Invalid scope. Must be 'client', 'server', or 'all'.");
 
         string? environment = null;
+        ProjectEnvironment? resolvedEnvironment = null;
         if (!string.IsNullOrWhiteSpace(request.Environment))
         {
             var requestedEnvironment = request.Environment.Trim();
-            var resolvedEnvironment = await environmentRepository.GetAsync(
+            resolvedEnvironment = await environmentRepository.GetAsync(
                 project.Name,
                 requestedEnvironment,
                 cancellationToken);
@@ -65,6 +66,24 @@ public class CreateApiKeyCommandHandler(
         };
 
         await apiKeyRepository.AddAsync(apiKey, cancellationToken);
+
+        // Do not disclose a credential if its authorized project was replaced during issuance.
+        var currentProject = await projectRepository.GetByNameAsync(project.Name, cancellationToken);
+        if (currentProject is null || currentProject.Id != project.Id || currentProject.CreatedAt != project.CreatedAt)
+        {
+            await apiKeyRepository.DeleteAsync(apiKey.Id, CancellationToken.None);
+            return new CreateApiKeyResult(false, null, "Project changed during credential creation. Try again.");
+        }
+
+        if (resolvedEnvironment is not null)
+        {
+            var currentEnvironment = await environmentRepository.GetAsync(project.Name, request.Environment!.Trim(), cancellationToken);
+            if (currentEnvironment is null || currentEnvironment.CreatedAt != resolvedEnvironment.CreatedAt)
+            {
+                await apiKeyRepository.DeleteAsync(apiKey.Id, CancellationToken.None);
+                return new CreateApiKeyResult(false, null, "Environment changed during credential creation. Try again.");
+            }
+        }
 
         return new CreateApiKeyResult(true, apiKey.ToCreatedDto(secret), null);
     }

--- a/core/src/Application/Admin/ParameterShareLinks/Commands/CreateParameterShareLinkCommand.cs
+++ b/core/src/Application/Admin/ParameterShareLinks/Commands/CreateParameterShareLinkCommand.cs
@@ -52,7 +52,8 @@ public class CreateParameterShareLinkCommandHandler(
         if (!await environmentRepository.ExistsAsync(projectName, request.EnvironmentName, cancellationToken))
             return new CreateParameterShareLinkResult(false, null, "Environment not found");
 
-        if (!await configEntryRepository.ExistsAsync(projectName, request.EnvironmentName, request.Key, cancellationToken))
+        var entry = await configEntryRepository.GetAsync(projectName, request.EnvironmentName, request.Key, cancellationToken);
+        if (entry is null)
             return new CreateParameterShareLinkResult(false, null, "Config entry not found");
 
         if (!TryResolveExpiration(request.Expiration, dateTime.NowUtc, out var expiresAt, out var expirationError))
@@ -74,6 +75,21 @@ public class CreateParameterShareLinkCommandHandler(
         };
 
         await shareLinkRepository.AddAsync(shareLink, cancellationToken);
+
+        // Do not disclose a credential if its authorized project was replaced during issuance.
+        var currentProject = await projectRepository.GetByNameAsync(project.Name, cancellationToken);
+        if (currentProject is null || currentProject.Id != project.Id || currentProject.CreatedAt != project.CreatedAt)
+        {
+            await shareLinkRepository.RevokeAsync(shareLink.Id, dateTime.NowUtc, CancellationToken.None);
+            return new CreateParameterShareLinkResult(false, null, "Project changed during credential creation. Try again.");
+        }
+
+        var currentEntry = await configEntryRepository.GetAsync(projectName, request.EnvironmentName, request.Key, cancellationToken);
+        if (currentEntry is null || currentEntry.CreatedAt != entry.CreatedAt)
+        {
+            await shareLinkRepository.RevokeAsync(shareLink.Id, dateTime.NowUtc, CancellationToken.None);
+            return new CreateParameterShareLinkResult(false, null, "Parameter changed during credential creation. Try again.");
+        }
 
         if (auditLogService is not null)
         {

--- a/core/src/Application/Api/ConfigEntries/Queries/GetAllConfigValuesQuery.cs
+++ b/core/src/Application/Api/ConfigEntries/Queries/GetAllConfigValuesQuery.cs
@@ -96,6 +96,9 @@ public class GetAllConfigValuesQueryHandler(
             normalizedPrefix,
             workingValues);
 
+        if (!await RuntimeApiKeyValidation.IsCurrentAsync(apiKeyRepository, apiKeyHash, lookupResult, cancellationToken))
+            return Failure("Invalid API key", RuntimeConfigErrorCodes.InvalidApiKey);
+
         return MatchesIfNoneMatch(request.IfNoneMatch, workingEtag)
             ? new GetAllConfigValuesResult(true, null, null, workingEtag, true)
             : new GetAllConfigValuesResult(true, workingValues, null, workingEtag);

--- a/core/src/Application/Api/ConfigEntries/Queries/GetAllReleaseConfigValuesQuery.cs
+++ b/core/src/Application/Api/ConfigEntries/Queries/GetAllReleaseConfigValuesQuery.cs
@@ -105,7 +105,11 @@ public class GetAllReleaseConfigValuesQueryHandler(
             ConfigEntryPrefix.Normalize(request.Prefix),
             release);
         if (GetAllConfigValuesQueryHandler.MatchesIfNoneMatch(request.IfNoneMatch, etag))
+        {
+            if (!await RuntimeApiKeyValidation.IsCurrentAsync(apiKeyRepository, apiKeyHash, lookupResult, cancellationToken))
+                return Failure("Invalid API key", RuntimeConfigErrorCodes.InvalidApiKey);
             return new GetAllConfigValuesResult(true, null, null, etag, true);
+        }
 
         var entries = string.IsNullOrEmpty(request.Prefix)
             ? await configReleaseRepository.ListEntriesAsync(
@@ -131,6 +135,9 @@ public class GetAllReleaseConfigValuesQueryHandler(
                     ConfigEntryContentTypes.Normalize(entry.ContentType)
                         ?? ConfigEntryContentTypes.Infer(entry.Value)),
                 StringComparer.Ordinal);
+
+        if (!await RuntimeApiKeyValidation.IsCurrentAsync(apiKeyRepository, apiKeyHash, lookupResult, cancellationToken))
+            return Failure("Invalid API key", RuntimeConfigErrorCodes.InvalidApiKey);
 
         return new GetAllConfigValuesResult(true, values, null, etag);
     }

--- a/core/src/Application/Api/ConfigEntries/Queries/GetConfigEntryValueQuery.cs
+++ b/core/src/Application/Api/ConfigEntries/Queries/GetConfigEntryValueQuery.cs
@@ -52,6 +52,9 @@ public class GetConfigEntryValueQueryHandler(
         if (configEntry is null || (configEntry.Scope & apiKeyScope) == 0)
             return Failure("Config entry not found", RuntimeConfigErrorCodes.ConfigEntryNotFound);
 
+        if (!await RuntimeApiKeyValidation.IsCurrentAsync(apiKeyRepository, apiKeyHash, lookupResult, cancellationToken))
+            return Failure("Invalid API key", RuntimeConfigErrorCodes.InvalidApiKey);
+
         return Success(configEntry.Value, configEntry.ContentType);
     }
 

--- a/core/src/Application/Api/ConfigEntries/Queries/GetReleaseConfigEntryValueQuery.cs
+++ b/core/src/Application/Api/ConfigEntries/Queries/GetReleaseConfigEntryValueQuery.cs
@@ -93,6 +93,9 @@ public class GetReleaseConfigEntryValueQueryHandler(
         if (releaseEntry.Entry is null)
             return Failure("Config entry not found", RuntimeConfigErrorCodes.ConfigEntryNotFound);
 
+        if (!await RuntimeApiKeyValidation.IsCurrentAsync(apiKeyRepository, apiKeyHash, lookupResult, cancellationToken))
+            return Failure("Invalid API key", RuntimeConfigErrorCodes.InvalidApiKey);
+
         return new GetConfigEntryValueResult(
             true,
             releaseEntry.Entry.Value,

--- a/core/src/Application/Api/ConfigEntries/Queries/RuntimeApiKeyValidation.cs
+++ b/core/src/Application/Api/ConfigEntries/Queries/RuntimeApiKeyValidation.cs
@@ -1,0 +1,20 @@
+using Nona.Domain.Interfaces;
+
+namespace Nona.Application.Api.ConfigEntries.Queries;
+
+internal static class RuntimeApiKeyValidation
+{
+    // Check after the protected read: deletion/recreation must not let an already-started
+    // request return data from a replacement resource using a now-deleted credential.
+    public static async Task<bool> IsCurrentAsync(IApiKeyRepository repository, string hash,
+        ApiKeyAuthenticationResult authorized, CancellationToken ct)
+    {
+        var current = await repository.GetByKeyHashAsync(hash, ct);
+        return current is not null
+            && current.Project.Id == authorized.Project.Id
+            && current.Project.CreatedAt == authorized.Project.CreatedAt
+            && string.Equals(current.Project.Name, authorized.Project.Name, StringComparison.OrdinalIgnoreCase)
+            && current.Scope == authorized.Scope
+            && string.Equals(current.Environment, authorized.Environment, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/core/src/Application/Auth/Commands/RegisterCommand.cs
+++ b/core/src/Application/Auth/Commands/RegisterCommand.cs
@@ -29,7 +29,7 @@ public class RegisterCommandHandler(IMediator mediator, IUserRepository userRepo
         var (hash, salt) = passwordHasher.HashPassword(request.Password);
         var now = dateTime.NowUtc;
 
-        await userRepository.AddAsync(new User
+        var created = await userRepository.TryAddFirstUserAsync(new User
         {
             Email = request.Email,
             Name = request.Email,
@@ -40,6 +40,9 @@ public class RegisterCommandHandler(IMediator mediator, IUserRepository userRepo
             CreatedAt = now,
             UpdatedAt = now
         }, cancellationToken);
+
+        if (!created)
+            return new RegisterResult(false, null, "Registration is disabled", AuthErrorCodes.RegistrationDisabled);
 
         var loginResult = await mediator.Send(new LoginCommand(request.Email, request.Password), cancellationToken);
         if (!loginResult.Success || loginResult.Response is null)

--- a/core/src/Application/Shared/ParameterShareLinks/Commands/UpdateSharedParameterCommand.cs
+++ b/core/src/Application/Shared/ParameterShareLinks/Commands/UpdateSharedParameterCommand.cs
@@ -81,7 +81,7 @@ public class UpdateSharedParameterCommandHandler(
             Environment = existingEntry.Environment,
             Key = existingEntry.Key,
             Value = request.Value,
-            ContentType = contentType,
+            ContentType = existingEntry.ContentType,
             Description = existingEntry.Description,
             Unit = existingEntry.Unit,
             Scope = existingEntry.Scope,
@@ -89,9 +89,10 @@ public class UpdateSharedParameterCommandHandler(
             UpdatedAt = now
         };
 
-        var savedEntry = await configEntryRepository.AddVersionAsync(
+        var savedEntry = await configEntryRepository.UpdateSharedValueAsync(
             updatedEntry,
-            SharedParameterMapping.ResolveActor(shareLink),
+            shareLink,
+            now,
             cancellationToken);
 
         if (savedEntry is null)

--- a/core/src/Application/Shared/ParameterShareLinks/Queries/GetSharedParameterQuery.cs
+++ b/core/src/Application/Shared/ParameterShareLinks/Queries/GetSharedParameterQuery.cs
@@ -39,10 +39,9 @@ public class GetSharedParameterQueryHandler(
         }
 
         var shareLink = resolution.ShareLink!;
-        var entry = await configEntryRepository.GetAsync(
-            shareLink.Project,
-            shareLink.Environment,
-            shareLink.Key,
+        var entry = await configEntryRepository.GetSharedAsync(
+            shareLink,
+            dateTime.NowUtc,
             cancellationToken);
 
         if (entry is null)

--- a/core/src/Domain/Interfaces/IConfigEntryRepository.cs
+++ b/core/src/Domain/Interfaces/IConfigEntryRepository.cs
@@ -6,6 +6,10 @@ public interface IConfigEntryRepository
 {
     Task<ConfigEntry?> GetAsync(string projectName, string environmentName, string key, CancellationToken ct = default);
 
+    Task<ConfigEntry?> GetSharedAsync(ParameterShareLink link, DateTime now, CancellationToken ct = default);
+
+    Task<ConfigEntry?> UpdateSharedValueAsync(ConfigEntry entry, ParameterShareLink link, DateTime now, CancellationToken ct = default);
+
     Task<ConfigEntry?> AddVersionAsync(ConfigEntry entry, string actor, CancellationToken ct = default);
 
     Task<IReadOnlyList<ConfigEntryVersion>> ListVersionsAsync(string projectName, string environmentName, string key, CancellationToken ct = default);

--- a/core/src/Domain/Interfaces/IUserRepository.cs
+++ b/core/src/Domain/Interfaces/IUserRepository.cs
@@ -15,6 +15,7 @@ public interface IUserRepository
 
     Task<bool> ExistsAnyAsync(CancellationToken ct = default);
     Task AddAsync(User user, CancellationToken ct = default);
+    Task<bool> TryAddFirstUserAsync(User user, CancellationToken ct = default);
     Task UpdateAsync(User user, CancellationToken ct = default);
     Task<bool> TryResetPasswordAsync(
         string passwordResetTokenHash,

--- a/core/src/Infrastructure/Repositories/InMemory/InMemoryApiKeyRepository.cs
+++ b/core/src/Infrastructure/Repositories/InMemory/InMemoryApiKeyRepository.cs
@@ -52,10 +52,12 @@ public sealed class InMemoryApiKeyRepository : IApiKeyRepository
 
     public Task AddAsync(ApiKey apiKey, CancellationToken ct = default)
     {
-        if (apiKey.Id == 0)
-            apiKey.Id = Interlocked.Increment(ref _nextId);
-
-        _apiKeys[apiKey.Id] = apiKey;
+        lock (InMemoryRepositoryGate.SyncRoot)
+        {
+            if (apiKey.Id == 0)
+                apiKey.Id = Interlocked.Increment(ref _nextId);
+            _apiKeys[apiKey.Id] = apiKey;
+        }
         return Task.CompletedTask;
     }
 
@@ -63,6 +65,23 @@ public sealed class InMemoryApiKeyRepository : IApiKeyRepository
     {
         _apiKeys.TryRemove(id, out _);
         return Task.CompletedTask;
+    }
+
+    internal void DeleteProject(string projectName)
+    {
+        foreach (var item in _apiKeys.Values)
+        {
+            if (string.Equals(item.Project, projectName, StringComparison.OrdinalIgnoreCase))
+                _apiKeys.TryRemove(item.Id, out _);
+        }
+    }
+
+    internal void DeleteEnvironment(string projectName, string environmentName)
+    {
+        foreach (var item in _apiKeys.Values)
+            if (string.Equals(item.Project, projectName, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(item.Environment, environmentName, StringComparison.OrdinalIgnoreCase))
+                _apiKeys.TryRemove(item.Id, out _);
     }
 
     internal void RenameEnvironment(string projectName, string currentName, string newName)

--- a/core/src/Infrastructure/Repositories/InMemory/InMemoryConfigEntryRepository.cs
+++ b/core/src/Infrastructure/Repositories/InMemory/InMemoryConfigEntryRepository.cs
@@ -9,7 +9,11 @@ public class InMemoryConfigEntryRepository : IConfigEntryRepository
 {
     private readonly ConcurrentDictionary<string, ConfigEntry> _entries = new(StringComparer.OrdinalIgnoreCase);
     private readonly ConcurrentDictionary<string, List<ConfigEntryVersion>> _versions = new(StringComparer.OrdinalIgnoreCase);
-    private readonly object _versionGate = new();
+    private readonly object _versionGate = InMemoryRepositoryGate.SyncRoot;
+    private readonly InMemoryParameterShareLinkRepository? _shareLinks;
+
+    public InMemoryConfigEntryRepository() { }
+    public InMemoryConfigEntryRepository(InMemoryParameterShareLinkRepository shareLinks) => _shareLinks = shareLinks;
 
     private static string GetKey(string projectName, string environmentName, string key) => $"{projectName}:{environmentName}:{key}";
 
@@ -26,6 +30,33 @@ public class InMemoryConfigEntryRepository : IConfigEntryRepository
         lock (_versionGate)
         {
             return Task.FromResult<ConfigEntry?>(AddVersionCore(entry, actor));
+        }
+    }
+
+    public Task<ConfigEntry?> GetSharedAsync(ParameterShareLink link, DateTime now, CancellationToken ct = default)
+    {
+        lock (_versionGate)
+        {
+            if (_shareLinks is null || !_shareLinks.IsActive(link, now)) return Task.FromResult<ConfigEntry?>(null);
+            return GetAsync(link.Project, link.Environment, link.Key, ct);
+        }
+    }
+
+    public Task<ConfigEntry?> UpdateSharedValueAsync(ConfigEntry entry, ParameterShareLink link, DateTime now, CancellationToken ct = default)
+    {
+        lock (_versionGate)
+        {
+            if (_shareLinks is null || !_shareLinks.IsActive(link, now, requireEdit: true)
+                || !string.Equals(entry.Project, link.Project, StringComparison.OrdinalIgnoreCase)
+                || !string.Equals(entry.Environment, link.Environment, StringComparison.OrdinalIgnoreCase)
+                || !string.Equals(entry.Key, link.Key, StringComparison.OrdinalIgnoreCase)
+                || !_entries.TryGetValue(GetKey(entry.Project, entry.Environment, entry.Key), out var current)
+                || current.ContentType != entry.ContentType)
+                return Task.FromResult<ConfigEntry?>(null);
+            var updated = CloneEntry(current, current.Project, current.Environment);
+            updated.Value = entry.Value;
+            updated.UpdatedAt = now;
+            return Task.FromResult<ConfigEntry?>(AddVersionCore(updated, $"Shared link #{link.Id}"));
         }
     }
 
@@ -105,20 +136,19 @@ public class InMemoryConfigEntryRepository : IConfigEntryRepository
     public Task DeleteAsync(string projectName, string environmentName, string key, CancellationToken ct = default)
     {
         var storageKey = GetKey(projectName, environmentName, key);
-        _entries.TryRemove(storageKey, out _);
-        _versions.TryRemove(storageKey, out _);
-        return Task.CompletedTask;
-    }
-
-    public Task DeleteManyAsync(string projectName, string environmentName, IEnumerable<string> keys, CancellationToken ct = default)
-    {
-        foreach (var key in keys)
+        lock (_versionGate)
         {
-            var storageKey = GetKey(projectName, environmentName, key);
+            _shareLinks?.DeleteEnvironment(projectName, environmentName, key);
             _entries.TryRemove(storageKey, out _);
             _versions.TryRemove(storageKey, out _);
         }
         return Task.CompletedTask;
+    }
+
+    public async Task DeleteManyAsync(string projectName, string environmentName, IEnumerable<string> keys, CancellationToken ct = default)
+    {
+        foreach (var key in keys)
+            await DeleteAsync(projectName, environmentName, key, ct);
     }
 
     public Task<int> CountAsync(CancellationToken ct = default)

--- a/core/src/Infrastructure/Repositories/InMemory/InMemoryEnvironmentRepository.cs
+++ b/core/src/Infrastructure/Repositories/InMemory/InMemoryEnvironmentRepository.cs
@@ -11,7 +11,7 @@ public class InMemoryEnvironmentRepository : IEnvironmentRepository
     private readonly InMemoryConfigReleaseRepository? _configReleaseRepository;
     private readonly InMemoryApiKeyRepository? _apiKeyRepository;
     private readonly InMemoryParameterShareLinkRepository? _parameterShareLinkRepository;
-    private readonly object _renameGate = new();
+    private readonly object _renameGate = InMemoryRepositoryGate.SyncRoot;
 
     public InMemoryEnvironmentRepository()
     {
@@ -64,7 +64,12 @@ public class InMemoryEnvironmentRepository : IEnvironmentRepository
 
     public Task DeleteAsync(string projectName, string environmentName, CancellationToken ct = default)
     {
-        _environments.TryRemove(GetKey(projectName, environmentName), out _);
+        lock (_renameGate)
+        {
+            _apiKeyRepository?.DeleteEnvironment(projectName, environmentName);
+            _parameterShareLinkRepository?.DeleteEnvironment(projectName, environmentName);
+            _environments.TryRemove(GetKey(projectName, environmentName), out _);
+        }
         return Task.CompletedTask;
     }
 

--- a/core/src/Infrastructure/Repositories/InMemory/InMemoryParameterShareLinkRepository.cs
+++ b/core/src/Infrastructure/Repositories/InMemory/InMemoryParameterShareLinkRepository.cs
@@ -8,6 +8,7 @@ public sealed class InMemoryParameterShareLinkRepository : IParameterShareLinkRe
 {
     private readonly ConcurrentDictionary<long, ParameterShareLink> _shareLinks = new();
     private long _nextId;
+    internal object SyncRoot => InMemoryRepositoryGate.SyncRoot;
 
     public Task<ParameterShareLink?> GetByIdAsync(long id, CancellationToken ct = default)
     {
@@ -43,23 +44,50 @@ public sealed class InMemoryParameterShareLinkRepository : IParameterShareLinkRe
 
     public Task AddAsync(ParameterShareLink shareLink, CancellationToken ct = default)
     {
-        if (shareLink.Id == 0)
+        lock (SyncRoot)
         {
-            shareLink.Id = Interlocked.Increment(ref _nextId);
+            if (shareLink.Id == 0) shareLink.Id = Interlocked.Increment(ref _nextId);
+            _shareLinks[shareLink.Id] = shareLink;
         }
-
-        _shareLinks[shareLink.Id] = shareLink;
         return Task.CompletedTask;
     }
 
     public Task RevokeAsync(long id, DateTime revokedAt, CancellationToken ct = default)
     {
-        if (_shareLinks.TryGetValue(id, out var shareLink))
-        {
-            shareLink.RevokedAt = revokedAt;
-        }
+        lock (SyncRoot)
+            if (_shareLinks.TryGetValue(id, out var shareLink))
+            {
+                shareLink.RevokedAt = revokedAt;
+            }
 
         return Task.CompletedTask;
+    }
+
+    internal bool IsActive(ParameterShareLink link, DateTime now, bool requireEdit = false)
+        => _shareLinks.TryGetValue(link.Id, out var current)
+            && current.TokenHash == link.TokenHash && (!requireEdit || current.CanEdit) && current.RevokedAt is null && current.ExpiresAt > now
+            && string.Equals(current.Project, link.Project, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(current.Environment, link.Environment, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(current.Key, link.Key, StringComparison.OrdinalIgnoreCase);
+
+    internal void DeleteProject(string projectName)
+    {
+        lock (SyncRoot)
+            foreach (var item in _shareLinks.Values)
+            {
+                if (string.Equals(item.Project, projectName, StringComparison.OrdinalIgnoreCase))
+                    _shareLinks.TryRemove(item.Id, out _);
+            }
+    }
+
+    internal void DeleteEnvironment(string projectName, string environmentName, string? key = null)
+    {
+        lock (SyncRoot)
+            foreach (var item in _shareLinks.Values)
+                if (string.Equals(item.Project, projectName, StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(item.Environment, environmentName, StringComparison.OrdinalIgnoreCase)
+                    && (key is null || string.Equals(item.Key, key, StringComparison.OrdinalIgnoreCase)))
+                    _shareLinks.TryRemove(item.Id, out _);
     }
 
     internal void RenameEnvironment(string projectName, string currentName, string newName)

--- a/core/src/Infrastructure/Repositories/InMemory/InMemoryProjectRepository.cs
+++ b/core/src/Infrastructure/Repositories/InMemory/InMemoryProjectRepository.cs
@@ -13,7 +13,7 @@ public class InMemoryProjectRepository : IProjectRepository
     private readonly InMemoryApiKeyRepository? _apiKeyRepository;
     private readonly InMemoryParameterShareLinkRepository? _parameterShareLinkRepository;
     private readonly InMemoryProjectMemberRepository? _projectMemberRepository;
-    private readonly object _renameGate = new();
+    private readonly object _renameGate = InMemoryRepositoryGate.SyncRoot;
     private long _nextId = 1;
 
     public InMemoryProjectRepository()
@@ -89,7 +89,12 @@ public class InMemoryProjectRepository : IProjectRepository
 
     public Task DeleteAsync(string name, CancellationToken ct = default)
     {
-        _projects.TryRemove(name, out _);
+        lock (_renameGate)
+        {
+            _apiKeyRepository?.DeleteProject(name);
+            _parameterShareLinkRepository?.DeleteProject(name);
+            _projects.TryRemove(name, out _);
+        }
         return Task.CompletedTask;
     }
 

--- a/core/src/Infrastructure/Repositories/InMemory/InMemoryRepositoryGate.cs
+++ b/core/src/Infrastructure/Repositories/InMemory/InMemoryRepositoryGate.cs
@@ -1,0 +1,7 @@
+namespace Nona.Infrastructure.Repositories.InMemory;
+
+// Capability issuance and resource deletion must not interleave their dictionary writes.
+internal static class InMemoryRepositoryGate
+{
+    internal static object SyncRoot { get; } = new();
+}

--- a/core/src/Infrastructure/Repositories/InMemory/InMemoryUserRepository.cs
+++ b/core/src/Infrastructure/Repositories/InMemory/InMemoryUserRepository.cs
@@ -8,6 +8,7 @@ public class InMemoryUserRepository : IUserRepository
 {
     private readonly ConcurrentDictionary<string, User> _users = new(StringComparer.OrdinalIgnoreCase);
     private long _nextId = 1;
+    private readonly object _userGate = new();
 
     public Task<User?> GetAsync(string email, CancellationToken ct = default)
     {
@@ -53,16 +54,28 @@ public class InMemoryUserRepository : IUserRepository
 
     public Task AddAsync(User user, CancellationToken ct = default)
     {
-        if (user.Id == 0)
-            user.Id = Interlocked.Increment(ref _nextId);
-        _users.TryAdd(user.Email, user);
+        lock (_userGate)
+        {
+            if (user.Id == 0)
+                user.Id = Interlocked.Increment(ref _nextId);
+            _users.TryAdd(user.Email, user);
+        }
         return Task.CompletedTask;
     }
 
+    public Task<bool> TryAddFirstUserAsync(User user, CancellationToken ct = default)
+    {
+        lock (_userGate)
+        {
+            if (!_users.IsEmpty) return Task.FromResult(false);
+            AddAsync(user, ct);
+            return Task.FromResult(true);
+        }
+    }
 
     public Task UpdateAsync(User user, CancellationToken ct = default)
     {
-        _users[user.Email] = user;
+        lock (_userGate) _users[user.Email] = user;
         return Task.CompletedTask;
     }
 
@@ -99,7 +112,7 @@ public class InMemoryUserRepository : IUserRepository
 
     public Task<bool> DeleteAsync(string email, CancellationToken ct = default)
     {
-        return Task.FromResult(_users.TryRemove(email, out _));
+        lock (_userGate) return Task.FromResult(_users.TryRemove(email, out _));
     }
 
     public Task<int> CountAsync(CancellationToken ct = default)

--- a/core/src/Infrastructure/Repositories/Libsql/LibsqlConfigEntryRepository.cs
+++ b/core/src/Infrastructure/Repositories/Libsql/LibsqlConfigEntryRepository.cs
@@ -58,6 +58,53 @@ public sealed class LibsqlConfigEntryRepository : IConfigEntryRepository
         return await AddVersionSequentialAsync(entry, normalizedActor, ct);
     }
 
+    public async Task<ConfigEntry?> GetSharedAsync(ParameterShareLink link, DateTime now, CancellationToken ct = default)
+    {
+        var result = await _client.ExecuteAsync(
+            """
+            SELECT e.Project, e.Environment, e.Key, e.Value, e.ContentType, e.Description, e.Unit, e.Scope, e.ActiveVersion, e.CreatedAt, e.UpdatedAt
+            FROM ConfigEntries e JOIN ParameterShareLinks s
+              ON e.Project = s.Project COLLATE NOCASE AND e.Environment = s.Environment COLLATE NOCASE AND e.Key = s.Key COLLATE NOCASE
+            WHERE s.Id = @Id AND s.TokenHash = @TokenHash AND s.RevokedAt IS NULL AND julianday(s.ExpiresAt) > julianday(@Now)
+            """, LibsqlParameters.Create(("Id", link.Id), ("TokenHash", link.TokenHash), ("Now", now.ToString("O"))), ct);
+        return result.Rows.Count == 0 ? null : Map(result.Rows[0]);
+    }
+
+    public async Task<ConfigEntry?> UpdateSharedValueAsync(ConfigEntry entry, ParameterShareLink link, DateTime now, CancellationToken ct = default)
+    {
+        var parameters = LibsqlParameters.Create(
+            ("Project", entry.Project), ("Environment", entry.Environment), ("Key", entry.Key),
+            ("Value", entry.Value), ("ContentType", entry.ContentType), ("Now", now.ToString("O")),
+            ("LinkId", link.Id), ("TokenHash", link.TokenHash));
+        var results = await _client.ExecuteBatchAsync(
+        [
+            new LibsqlStatement(
+                """
+                UPDATE ConfigEntries
+                SET Value = @Value, UpdatedAt = @Now,
+                    ActiveVersion = (SELECT COALESCE(MAX(Version), 0) + 1 FROM ConfigEntryVersions
+                        WHERE Project = @Project COLLATE NOCASE AND Environment = @Environment COLLATE NOCASE AND Key = @Key COLLATE NOCASE)
+                WHERE Project = @Project COLLATE NOCASE AND Environment = @Environment COLLATE NOCASE AND Key = @Key COLLATE NOCASE
+                  AND ContentType = @ContentType
+                  AND EXISTS (SELECT 1 FROM ParameterShareLinks
+                    WHERE Id = @LinkId AND TokenHash = @TokenHash AND CanEdit = 1 AND RevokedAt IS NULL
+                      AND julianday(ExpiresAt) > julianday(@Now)
+                      AND Project = @Project COLLATE NOCASE AND Environment = @Environment COLLATE NOCASE AND Key = @Key COLLATE NOCASE)
+                RETURNING Project, Environment, Key, Value, ContentType, Description, Unit, Scope, ActiveVersion, CreatedAt, UpdatedAt
+                """, parameters),
+            new LibsqlStatement(
+                """
+                INSERT INTO ConfigEntryVersions (Project, Environment, Key, Version, Value, ContentType, Description, Unit, Scope, CreatedAt, Actor)
+                SELECT Project, Environment, Key, ActiveVersion, Value, ContentType, Description, Unit, Scope, UpdatedAt, @Actor
+                FROM ConfigEntries
+                WHERE Project = @Project COLLATE NOCASE AND Environment = @Environment COLLATE NOCASE AND Key = @Key COLLATE NOCASE
+                  AND changes() > 0
+                """, LibsqlParameters.Create(("Project", entry.Project), ("Environment", entry.Environment),
+                    ("Key", entry.Key), ("Actor", $"Shared link #{link.Id}")))
+        ], ct);
+        return results[0].Rows.Count == 0 ? null : Map(results[0].Rows[0]);
+    }
+
     public async Task<IReadOnlyList<ConfigEntryVersion>> ListVersionsAsync(string projectName, string environmentName, string key, CancellationToken ct = default)
     {
         var result = await _client.ExecuteAsync(
@@ -174,6 +221,9 @@ public sealed class LibsqlConfigEntryRepository : IConfigEntryRepository
     {
         await _client.ExecuteBatchAsync(
             [
+                new LibsqlStatement(
+                    "DELETE FROM ParameterShareLinks WHERE Project = @ProjectName COLLATE NOCASE AND Environment = @EnvironmentName COLLATE NOCASE AND Key = @Key COLLATE NOCASE",
+                    CreateKeyParameters(projectName, environmentName, key)),
                 new LibsqlStatement(
                     """
                     DELETE FROM ConfigEntryVersions

--- a/core/src/Infrastructure/Repositories/Libsql/LibsqlEnvironmentRepository.cs
+++ b/core/src/Infrastructure/Repositories/Libsql/LibsqlEnvironmentRepository.cs
@@ -126,16 +126,13 @@ public sealed class LibsqlEnvironmentRepository : IEnvironmentRepository
 
     public async Task DeleteAsync(string projectName, string environmentName, CancellationToken ct = default)
     {
-        await _client.ExecuteAsync(
-            """
-            DELETE FROM Environments
-            WHERE Project = @ProjectName COLLATE NOCASE
-              AND Name = @EnvironmentName COLLATE NOCASE
-            """,
-            LibsqlParameters.Create(
-                ("ProjectName", projectName),
-                ("EnvironmentName", environmentName)),
-            ct);
+        var parameters = LibsqlParameters.Create(("ProjectName", projectName), ("EnvironmentName", environmentName));
+        await _client.ExecuteBatchAsync(
+        [
+            new LibsqlStatement("DELETE FROM ApiKeys WHERE Project = @ProjectName COLLATE NOCASE AND Environment = @EnvironmentName COLLATE NOCASE", parameters),
+            new LibsqlStatement("DELETE FROM ParameterShareLinks WHERE Project = @ProjectName COLLATE NOCASE AND Environment = @EnvironmentName COLLATE NOCASE", parameters),
+            new LibsqlStatement("DELETE FROM Environments WHERE Project = @ProjectName COLLATE NOCASE AND Name = @EnvironmentName COLLATE NOCASE", parameters)
+        ], ct);
     }
 
     private static ProjectEnvironment Map(LibsqlRow row)

--- a/core/src/Infrastructure/Repositories/Libsql/LibsqlProjectRepository.cs
+++ b/core/src/Infrastructure/Repositories/Libsql/LibsqlProjectRepository.cs
@@ -118,13 +118,13 @@ public sealed class LibsqlProjectRepository : IProjectRepository
 
     public async Task DeleteAsync(string name, CancellationToken ct = default)
     {
-        await _client.ExecuteAsync(
-            """
-            DELETE FROM Projects
-            WHERE Name = @Name COLLATE NOCASE
-            """,
-            LibsqlParameters.Create(("Name", name)),
-            ct);
+        var parameters = LibsqlParameters.Create(("Name", name));
+        await _client.ExecuteBatchAsync(
+        [
+            new LibsqlStatement("DELETE FROM ApiKeys WHERE Project = @Name COLLATE NOCASE", parameters),
+            new LibsqlStatement("DELETE FROM ParameterShareLinks WHERE Project = @Name COLLATE NOCASE", parameters),
+            new LibsqlStatement("DELETE FROM Projects WHERE Name = @Name COLLATE NOCASE", parameters)
+        ], ct);
     }
 
     public async Task<int> CountAsync(CancellationToken ct = default)

--- a/core/src/Infrastructure/Repositories/Libsql/LibsqlUserRepository.cs
+++ b/core/src/Infrastructure/Repositories/Libsql/LibsqlUserRepository.cs
@@ -109,6 +109,12 @@ public sealed class LibsqlUserRepository : IUserRepository
     }
 
     public async Task AddAsync(User user, CancellationToken ct = default)
+        => await InsertAsync(user, firstUserOnly: false, ct);
+
+    public Task<bool> TryAddFirstUserAsync(User user, CancellationToken ct = default)
+        => InsertAsync(user, firstUserOnly: true, ct);
+
+    private async Task<bool> InsertAsync(User user, bool firstUserOnly, CancellationToken ct)
     {
         var columns = new List<string>
         {
@@ -142,12 +148,16 @@ public sealed class LibsqlUserRepository : IUserRepository
         var values = columns.Select(column => $"@{column}");
         var sql = $"""
             INSERT INTO Users ({string.Join(", ", columns)})
-            VALUES ({string.Join(", ", values)})
+            SELECT {string.Join(", ", values)}
+            WHERE @FirstUserOnly = 0 OR NOT EXISTS (SELECT 1 FROM Users)
             """;
 
+        parameters["FirstUserOnly"] = firstUserOnly ? 1 : 0;
         var result = await _client.ExecuteAsync(sql, parameters, ct);
 
-        user.Id = result.LastInsertRowId ?? 0;
+        if (result.AffectedRowCount > 0)
+            user.Id = result.LastInsertRowId ?? 0;
+        return result.AffectedRowCount > 0;
     }
 
     public async Task UpdateAsync(User user, CancellationToken ct = default)

--- a/core/src/Infrastructure/Services/JwtTokenService.cs
+++ b/core/src/Infrastructure/Services/JwtTokenService.cs
@@ -3,12 +3,30 @@ using Microsoft.IdentityModel.JsonWebTokens;
 using Microsoft.IdentityModel.Tokens;
 using Nona.Domain.Entities;
 using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Globalization;
 using System.Text;
 
 namespace Nona.Infrastructure.Services;
 
 public class JwtTokenService(IConfiguration configuration) : IJwtTokenService
 {
+    public const string CredentialStampClaim = "nona_credential_stamp";
+
+    // Keyed binding: never expose the stored password hash in a readable JWT payload.
+    // Password writes automatically invalidate sessions without timestamp precision races.
+    public static string GetCredentialStamp(User user, string signingKey)
+    {
+        var createdAt = user.CreatedAt.Kind == DateTimeKind.Unspecified
+            ? DateTime.SpecifyKind(user.CreatedAt, DateTimeKind.Utc) : user.CreatedAt.ToUniversalTime();
+        var state = string.Join("\n", "nona-session-v1",
+            user.Id.ToString(CultureInfo.InvariantCulture),
+            createdAt.Ticks.ToString(CultureInfo.InvariantCulture),
+            user.PasswordHash ?? "", user.PasswordSalt ?? "");
+        return Convert.ToHexString(HMACSHA256.HashData(
+            Encoding.UTF8.GetBytes(signingKey), Encoding.UTF8.GetBytes(state)));
+    }
+
     public string GenerateToken(User user)
     {
         var key = configuration["Jwt:Key"] ?? throw new InvalidOperationException("JWT Key is not configured");
@@ -24,7 +42,8 @@ public class JwtTokenService(IConfiguration configuration) : IJwtTokenService
             [
                 new Claim(JwtRegisteredClaimNames.Sub, user.Email),
                 new Claim(ClaimTypes.Name, user.Email),
-                new Claim(ClaimTypes.Role, user.Role.ToString())
+                new Claim(ClaimTypes.Role, user.Role.ToString()),
+                new Claim(CredentialStampClaim, GetCredentialStamp(user, key))
             ]),
             Expires = DateTime.UtcNow.AddHours(24),
             Issuer = issuer,

--- a/core/src/WebApi/ConfigureServices.cs
+++ b/core/src/WebApi/ConfigureServices.cs
@@ -8,6 +8,9 @@ using Nona.WebApi.Authorization;
 using Nona.WebApi.Endpoints;
 using Nona.WebApi.Services;
 using System.Text;
+using System.Security.Claims;
+using Nona.Domain.Interfaces;
+using Nona.Infrastructure.Services;
 
 namespace Nona.WebApi;
 
@@ -49,6 +52,19 @@ public static class ConfigureServices
 
             options.Events = new JwtBearerEvents
             {
+                OnTokenValidated = async context =>
+                {
+                    var email = context.Principal?.FindFirstValue(ClaimTypes.Name);
+                    var stamp = context.Principal?.FindFirstValue(JwtTokenService.CredentialStampClaim);
+                    var repository = context.HttpContext.RequestServices.GetRequiredService<IUserRepository>();
+                    var user = string.IsNullOrEmpty(email) ? null
+                        : await repository.GetAsync(email, context.HttpContext.RequestAborted);
+                    if (user is null || string.IsNullOrEmpty(stamp)
+                        || !string.Equals(stamp, JwtTokenService.GetCredentialStamp(user, jwtKey), StringComparison.Ordinal))
+                    {
+                        context.Fail("The session is no longer valid. Sign in again.");
+                    }
+                },
                 OnChallenge = async context =>
                 {
                     context.HandleResponse();

--- a/core/tests/Application.Tests/ApiKeys/ApiKeyCommandTests.cs
+++ b/core/tests/Application.Tests/ApiKeys/ApiKeyCommandTests.cs
@@ -17,6 +17,46 @@ public class ApiKeyCommandTests
     private const string EnvironmentName = "production";
 
     [Test]
+    public async Task RecreatedEnvironmentDuringIssuanceDoesNotReceiveCredential()
+    {
+        var fixture = new TestFixture();
+        fixture.SetupAsSystemAdmin();
+        SetupProject(fixture);
+        fixture.SetupEnvironmentExists(ProjectName, EnvironmentName);
+        fixture.ApiKeyRepository.When(repository => repository.AddAsync(Arg.Any<ApiKey>(), Arg.Any<CancellationToken>()))
+            .Do(call =>
+            {
+                call.ArgAt<ApiKey>(0).Id = 43;
+                fixture.EnvironmentRepository.GetAsync(ProjectName, EnvironmentName, Arg.Any<CancellationToken>())
+                    .Returns(new ProjectEnvironment { Project = ProjectName, Name = EnvironmentName, CreatedAt = DateTime.UtcNow.AddDays(1) });
+            });
+        var result = await CreateCreateHandler(fixture).Handle(new CreateApiKeyCommand(ProjectName, "key", EnvironmentName, null), default);
+        await Assert.That(result.Success).IsFalse();
+        await Assert.That(result.ApiKey).IsNull();
+        await fixture.ApiKeyRepository.Received(1).DeleteAsync(43, CancellationToken.None);
+    }
+
+    [Test]
+    public async Task RecreatedProjectDuringIssuanceDoesNotReceiveOldCredential()
+    {
+        var fixture = new TestFixture();
+        fixture.SetupAsSystemAdmin();
+        SetupProject(fixture);
+        fixture.ApiKeyRepository.When(repository => repository.AddAsync(Arg.Any<ApiKey>(), Arg.Any<CancellationToken>()))
+            .Do(call =>
+            {
+                call.ArgAt<ApiKey>(0).Id = 42;
+                fixture.ProjectRepository.GetByNameAsync(ProjectName, Arg.Any<CancellationToken>())
+                    .Returns(new Project { Name = ProjectName, CreatedAt = DateTime.UtcNow.AddDays(1) });
+            });
+        var result = await CreateCreateHandler(fixture).Handle(
+            new CreateApiKeyCommand(ProjectName, "key", null, null), default);
+        await Assert.That(result.Success).IsFalse();
+        await Assert.That(result.ApiKey).IsNull();
+        await fixture.ApiKeyRepository.Received(1).DeleteAsync(42, CancellationToken.None);
+    }
+
+    [Test]
     public async Task SystemAdmin_CanCreateProjectScopedApiKey()
     {
         var fixture = new TestFixture();

--- a/core/tests/Application.Tests/Auth/RegisterCommandTests.cs
+++ b/core/tests/Application.Tests/Auth/RegisterCommandTests.cs
@@ -19,7 +19,18 @@ public class RegisterCommandTests
     public RegisterCommandTests()
     {
         _dateTime.NowUtc.Returns(new DateTime(2026, 6, 3, 12, 0, 0, DateTimeKind.Utc));
+        _userRepository.TryAddFirstUserAsync(Arg.Any<User>(), Arg.Any<CancellationToken>()).Returns(true);
         _passwordHasher.HashPassword("Password123!").Returns(("hashed-password", string.Empty));
+    }
+
+    [Test]
+    public async Task LosingBootstrapRaceDoesNotLogIn()
+    {
+        _userRepository.TryAddFirstUserAsync(Arg.Any<User>(), Arg.Any<CancellationToken>()).Returns(false);
+        var handler = new RegisterCommandHandler(_mediator, _userRepository, _dateTime, _passwordHasher);
+        var result = await handler.Handle(new RegisterCommand("admin@example.com", "Password123!"), default);
+        await Assert.That(result.ErrorCode).IsEqualTo(AuthErrorCodes.RegistrationDisabled);
+        await _mediator.DidNotReceive().Send(Arg.Any<LoginCommand>(), Arg.Any<CancellationToken>());
     }
 
     [Test]
@@ -41,7 +52,7 @@ public class RegisterCommandTests
         await Assert.That(result.Success).IsTrue();
         await Assert.That(result.Response).IsNotNull();
         await Assert.That(result.Response!.Token).IsEqualTo("jwt-token");
-        await _userRepository.Received(1).AddAsync(Arg.Is<User>(user =>
+        await _userRepository.Received(1).TryAddFirstUserAsync(Arg.Is<User>(user =>
             user.Email == "admin@example.com" &&
             user.Role == UserRole.Admin &&
             user.PasswordHash == "hashed-password"), Arg.Any<CancellationToken>());
@@ -79,7 +90,7 @@ public class RegisterCommandTests
         await Assert.That(result.Error).IsEqualTo("User already exists");
         await Assert.That(result.ErrorCode).IsEqualTo(AuthErrorCodes.UserAlreadyExists);
         await _userRepository.DidNotReceive()
-            .AddAsync(Arg.Any<User>(), Arg.Any<CancellationToken>());
+            .TryAddFirstUserAsync(Arg.Any<User>(), Arg.Any<CancellationToken>());
     }
 
     [Test]
@@ -97,6 +108,6 @@ public class RegisterCommandTests
         await Assert.That(result.Error).IsEqualTo("Registration is disabled");
         await Assert.That(result.ErrorCode).IsEqualTo(AuthErrorCodes.RegistrationDisabled);
         await _userRepository.DidNotReceive()
-            .AddAsync(Arg.Any<User>(), Arg.Any<CancellationToken>());
+            .TryAddFirstUserAsync(Arg.Any<User>(), Arg.Any<CancellationToken>());
     }
 }

--- a/core/tests/Application.Tests/ParameterShareLinks/CreateParameterShareLinkCommandTests.cs
+++ b/core/tests/Application.Tests/ParameterShareLinks/CreateParameterShareLinkCommandTests.cs
@@ -15,6 +15,56 @@ public class CreateParameterShareLinkCommandTests
     private const string ConfigKey = "API_URL";
 
     [Test]
+    public async Task RecreatedParameterDuringIssuanceRevokesLinkBeforeDisclosure()
+    {
+        var fixture = new TestFixture();
+        fixture.SetupAsSystemAdmin();
+        fixture.SetupProjectExists(ProjectName);
+        fixture.SetupEnvironmentExists(ProjectName, EnvironmentName);
+        fixture.SetupConfigEntryExists(ProjectName, EnvironmentName, ConfigKey);
+        var links = Substitute.For<IParameterShareLinkRepository>();
+        links.When(repository => repository.AddAsync(Arg.Any<ParameterShareLink>(), Arg.Any<CancellationToken>()))
+            .Do(call =>
+            {
+                call.ArgAt<ParameterShareLink>(0).Id = 43;
+                fixture.ConfigEntryRepository.GetAsync(ProjectName, EnvironmentName, ConfigKey, Arg.Any<CancellationToken>())
+                    .Returns(new ConfigEntry { Project = ProjectName, Environment = EnvironmentName, Key = ConfigKey, Value = "replacement", CreatedAt = DateTime.UtcNow.AddDays(1) });
+            });
+        var handler = new CreateParameterShareLinkCommandHandler(fixture.ProjectRepository,
+            fixture.EnvironmentRepository, fixture.ConfigEntryRepository, links, fixture.ProjectAccessService, fixture.DateTime);
+        var result = await handler.Handle(new CreateParameterShareLinkCommand(ProjectName, EnvironmentName, ConfigKey, null, true), default);
+        await Assert.That(result.Success).IsFalse();
+        await Assert.That(result.ShareLink).IsNull();
+        await links.Received(1).RevokeAsync(43, Arg.Any<DateTime>(), CancellationToken.None);
+    }
+
+    [Test]
+    public async Task RecreatedProjectDuringIssuanceRevokesLinkBeforeDisclosure()
+    {
+        var fixture = new TestFixture();
+        fixture.SetupAsSystemAdmin();
+        fixture.SetupProjectExists(ProjectName);
+        fixture.SetupEnvironmentExists(ProjectName, EnvironmentName);
+        fixture.SetupConfigEntryExists(ProjectName, EnvironmentName, ConfigKey);
+        var links = Substitute.For<IParameterShareLinkRepository>();
+        links.When(repository => repository.AddAsync(Arg.Any<ParameterShareLink>(), Arg.Any<CancellationToken>()))
+            .Do(call =>
+            {
+                call.ArgAt<ParameterShareLink>(0).Id = 42;
+                fixture.ProjectRepository.GetByNameAsync(ProjectName, Arg.Any<CancellationToken>())
+                    .Returns(new Project { Name = ProjectName, CreatedAt = DateTime.UtcNow.AddDays(1) });
+            });
+        var handler = new CreateParameterShareLinkCommandHandler(fixture.ProjectRepository,
+            fixture.EnvironmentRepository, fixture.ConfigEntryRepository, links,
+            fixture.ProjectAccessService, fixture.DateTime);
+        var result = await handler.Handle(
+            new CreateParameterShareLinkCommand(ProjectName, EnvironmentName, ConfigKey, null, true), default);
+        await Assert.That(result.Success).IsFalse();
+        await Assert.That(result.ShareLink).IsNull();
+        await links.Received(1).RevokeAsync(42, Arg.Any<DateTime>(), CancellationToken.None);
+    }
+
+    [Test]
     public async Task CreateShareLink_StoresHashAndReturnsSixteenCharacterToken()
     {
         var now = new DateTime(2026, 7, 2, 12, 0, 0, DateTimeKind.Utc);

--- a/core/tests/Application.Tests/ParameterShareLinks/SharedParameterCommandTests.cs
+++ b/core/tests/Application.Tests/ParameterShareLinks/SharedParameterCommandTests.cs
@@ -28,7 +28,7 @@ public class SharedParameterCommandTests
         dateTime.NowUtc.Returns(_now);
         shareLinkRepository.GetByTokenHashAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns(EditableLink());
-        configEntryRepository.GetAsync(ProjectName, EnvironmentName, ConfigKey, Arg.Any<CancellationToken>())
+        configEntryRepository.GetSharedAsync(Arg.Any<ParameterShareLink>(), _now, Arg.Any<CancellationToken>())
             .Returns(Entry("https://api.example.com"));
 
         var handler = new GetSharedParameterQueryHandler(
@@ -75,10 +75,9 @@ public class SharedParameterCommandTests
 
         await Assert.That(result.Success).IsFalse();
         await Assert.That(result.ErrorCode).IsEqualTo(ParameterShareLinkErrorCodes.Expired);
-        await configEntryRepository.DidNotReceive().GetAsync(
-            Arg.Any<string>(),
-            Arg.Any<string>(),
-            Arg.Any<string>(),
+        await configEntryRepository.DidNotReceive().GetSharedAsync(
+            Arg.Any<ParameterShareLink>(),
+            Arg.Any<DateTime>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -103,10 +102,9 @@ public class SharedParameterCommandTests
 
         await Assert.That(result.Success).IsFalse();
         await Assert.That(result.ErrorCode).IsEqualTo(ParameterShareLinkErrorCodes.Revoked);
-        await configEntryRepository.DidNotReceive().GetAsync(
-            Arg.Any<string>(),
-            Arg.Any<string>(),
-            Arg.Any<string>(),
+        await configEntryRepository.DidNotReceive().GetSharedAsync(
+            Arg.Any<ParameterShareLink>(),
+            Arg.Any<DateTime>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -131,9 +129,10 @@ public class SharedParameterCommandTests
 
         await Assert.That(result.Success).IsFalse();
         await Assert.That(result.ErrorCode).IsEqualTo(ParameterShareLinkErrorCodes.ViewOnly);
-        await configEntryRepository.DidNotReceive().AddVersionAsync(
+        await configEntryRepository.DidNotReceive().UpdateSharedValueAsync(
             Arg.Any<ConfigEntry>(),
-            Arg.Any<string>(),
+            Arg.Any<ParameterShareLink>(),
+            Arg.Any<DateTime>(),
             Arg.Any<CancellationToken>());
     }
 
@@ -152,9 +151,10 @@ public class SharedParameterCommandTests
         configEntryRepository.GetAsync(ProjectName, EnvironmentName, ConfigKey, Arg.Any<CancellationToken>())
             .Returns(Entry("https://api.example.com"));
         configEntryRepository
-            .AddVersionAsync(
+            .UpdateSharedValueAsync(
                 Arg.Do<ConfigEntry>(entry => savedEntry = entry),
-                "Shared link #7",
+                Arg.Is<ParameterShareLink>(link => link.Id == 7),
+                _now,
                 Arg.Any<CancellationToken>())
             .Returns(call => call.ArgAt<ConfigEntry>(0));
 
@@ -200,9 +200,10 @@ public class SharedParameterCommandTests
             .Returns(EditableLink());
         configEntryRepository.GetAsync(ProjectName, EnvironmentName, ConfigKey, Arg.Any<CancellationToken>())
             .Returns(Entry("100", "number", "ms", "Request timeout"));
-        configEntryRepository.AddVersionAsync(
+        configEntryRepository.UpdateSharedValueAsync(
                 Arg.Do<ConfigEntry>(entry => savedEntry = entry),
-                Arg.Any<string>(),
+                Arg.Any<ParameterShareLink>(),
+                _now,
                 Arg.Any<CancellationToken>())
             .Returns(call => call.ArgAt<ConfigEntry>(0));
 

--- a/core/tests/Infrastructure.Tests/ConfigEntryUpdateReadHistoryFlowTests.cs
+++ b/core/tests/Infrastructure.Tests/ConfigEntryUpdateReadHistoryFlowTests.cs
@@ -229,9 +229,9 @@ public class ConfigEntryUpdateReadHistoryFlowTests
 
         var projectRepository = new InMemoryProjectRepository();
         var environmentRepository = new InMemoryEnvironmentRepository();
-        var configEntryRepository = new InMemoryConfigEntryRepository();
-        var configReleaseRepository = new InMemoryConfigReleaseRepository();
         var shareLinkRepository = new InMemoryParameterShareLinkRepository();
+        var configEntryRepository = new InMemoryConfigEntryRepository(shareLinkRepository);
+        var configReleaseRepository = new InMemoryConfigReleaseRepository();
         var apiKeyRepository = new InMemoryApiKeyRepository(projectRepository);
         var accessService = new AllowAllProjectAccessService();
         var currentUser = new MutableCurrentUserService("alice");

--- a/core/tests/Infrastructure.Tests/PasswordChangeEndpointTests.cs
+++ b/core/tests/Infrastructure.Tests/PasswordChangeEndpointTests.cs
@@ -23,7 +23,7 @@ public class PasswordChangeEndpointTests
     private const string NewPassword = "NewPassword123!";
 
     [Test]
-    public async Task PasswordUserCanChangePasswordAndKeepCurrentToken()
+    public async Task PasswordUserCanChangePasswordAndRevokeCurrentToken()
     {
         await using var app = await StartAppAsync();
         var client = app.GetTestClient();
@@ -92,7 +92,7 @@ public class PasswordChangeEndpointTests
             "/auth/me",
             session.Token))
         {
-            await Assert.That(existingTokenResponse.StatusCode).IsEqualTo(HttpStatusCode.OK);
+            await Assert.That(existingTokenResponse.StatusCode).IsEqualTo(HttpStatusCode.Unauthorized);
         }
 
         using var oldLogin = await client.PostAsJsonAsync(
@@ -103,6 +103,10 @@ public class PasswordChangeEndpointTests
             new { email = session.Email, password = NewPassword });
         await Assert.That(oldLogin.StatusCode).IsEqualTo(HttpStatusCode.Unauthorized);
         await Assert.That(newLogin.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        using var loginBody = await ParseJsonAsync(newLogin);
+        using var freshSession = await SendAuthorizedAsync(client, HttpMethod.Get, "/auth/me",
+            loginBody.RootElement.GetProperty("token").GetString()!);
+        await Assert.That(freshSession.StatusCode).IsEqualTo(HttpStatusCode.OK);
     }
 
     [Test]
@@ -141,6 +145,29 @@ public class PasswordChangeEndpointTests
             "/auth/password",
             new { currentPassword = "current", newPassword = NewPassword });
         await Assert.That(anonymousResponse.StatusCode).IsEqualTo(HttpStatusCode.Unauthorized);
+    }
+
+    [Test]
+    public async Task TokenWithoutCredentialBindingIsRejected()
+    {
+        await using var app = await StartAppAsync();
+        var client = app.GetTestClient();
+        var session = await RegisterAsync(client);
+        var configuration = app.Services.GetRequiredService<IConfiguration>();
+        var legacyToken = new Microsoft.IdentityModel.JsonWebTokens.JsonWebTokenHandler().CreateToken(
+            new Microsoft.IdentityModel.Tokens.SecurityTokenDescriptor
+            {
+                Subject = new System.Security.Claims.ClaimsIdentity([
+                    new System.Security.Claims.Claim(System.Security.Claims.ClaimTypes.Name, session.Email)]),
+                Issuer = configuration["Jwt:Issuer"],
+                Audience = configuration["Jwt:Audience"],
+                Expires = DateTime.UtcNow.AddHours(1),
+                SigningCredentials = new Microsoft.IdentityModel.Tokens.SigningCredentials(
+                    new Microsoft.IdentityModel.Tokens.SymmetricSecurityKey(System.Text.Encoding.UTF8.GetBytes(configuration["Jwt:Key"]!)),
+                    Microsoft.IdentityModel.Tokens.SecurityAlgorithms.HmacSha256)
+            });
+        using var response = await SendAuthorizedAsync(client, HttpMethod.Get, "/auth/me", legacyToken);
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Unauthorized);
     }
 
     private static async Task<Session> RegisterAsync(HttpClient client)

--- a/core/tests/Infrastructure.Tests/PasswordResetEndpointTests.cs
+++ b/core/tests/Infrastructure.Tests/PasswordResetEndpointTests.cs
@@ -73,6 +73,9 @@ public class PasswordResetEndpointTests
                 .IsEqualTo("password_reset_invalid_or_used");
         }
 
+        using var staleSession = await SendAuthorizedAsync(client, HttpMethod.Get, "/auth/me", user.Token);
+        await Assert.That(staleSession.StatusCode).IsEqualTo(HttpStatusCode.Unauthorized);
+
         using var oldLogin = await client.PostAsJsonAsync(
             "/auth/login",
             new { email = user.Email, password = OldPassword });
@@ -81,6 +84,10 @@ public class PasswordResetEndpointTests
             new { email = user.Email, password = NewPassword });
         await Assert.That(oldLogin.StatusCode).IsEqualTo(HttpStatusCode.Unauthorized);
         await Assert.That(newLogin.StatusCode).IsEqualTo(HttpStatusCode.OK);
+        using var loginBody = await ParseJsonAsync(newLogin);
+        using var freshSession = await SendAuthorizedAsync(client, HttpMethod.Get, "/auth/me",
+            loginBody.RootElement.GetProperty("token").GetString()!);
+        await Assert.That(freshSession.StatusCode).IsEqualTo(HttpStatusCode.OK);
     }
 
     [Test]

--- a/core/tests/Infrastructure.Tests/ProjectCredentialDeletionTests.cs
+++ b/core/tests/Infrastructure.Tests/ProjectCredentialDeletionTests.cs
@@ -1,0 +1,97 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Nona.Domain.Entities;
+using Nona.Domain.Interfaces;
+using Nona.Infrastructure.Configuration;
+using Nona.Infrastructure.Services;
+using Nona.Libsql;
+
+namespace Nona.Infrastructure.Tests;
+
+public class ProjectCredentialDeletionTests
+{
+    [Test]
+    [Arguments("InMemory")]
+    [Arguments("Sqlite")]
+    public async Task RecreatedProjectCannotReuseCredentials(string storage)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"nona-credentials-{Guid.NewGuid():N}.db");
+        try
+        {
+            var configuration = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Storage:Type"] = storage,
+                ["Storage:Sqlite:DataSource"] = path
+            }).Build();
+            using var services = new ServiceCollection().AddStorageProvider(configuration).BuildServiceProvider();
+            if (storage == "Sqlite")
+                await new LibsqlDatabaseInitializer(services.GetRequiredService<ILibsqlDatabaseClient>()).StartAsync(default);
+            var users = services.GetRequiredService<IUserRepository>();
+            var user = new User
+            {
+                Email = "admin@example.com",
+                Name = "Admin",
+                PasswordHash = "old-hash",
+                CreatedAt = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Unspecified),
+                PasswordResetTokenHash = "reset",
+                PasswordResetTokenExpiresAt = DateTime.UtcNow.AddHours(1)
+            };
+            await users.AddAsync(user);
+            var stamp = JwtTokenService.GetCredentialStamp(user, "test-signing-key");
+            var stored = (await users.GetAsync(user.Email))!;
+            await Assert.That(JwtTokenService.GetCredentialStamp(stored, "test-signing-key")).IsEqualTo(stamp);
+            stored.Name = "Renamed";
+            await users.UpdateAsync(stored);
+            await Assert.That(JwtTokenService.GetCredentialStamp((await users.GetAsync(user.Email))!, "test-signing-key")).IsEqualTo(stamp);
+            await Assert.That(await users.TryResetPasswordAsync("reset", DateTime.UtcNow, "new-hash", "", DateTime.UtcNow)).IsTrue();
+            await Assert.That(JwtTokenService.GetCredentialStamp((await users.GetAsync(user.Email))!, "test-signing-key")).IsNotEqualTo(stamp);
+            var projects = services.GetRequiredService<IProjectRepository>();
+            var keys = services.GetRequiredService<IApiKeyRepository>();
+            var links = services.GetRequiredService<IParameterShareLinkRepository>();
+            await projects.AddAsync(new Project { Name = "Alpha", UrlSlug = "alpha" });
+            await projects.AddAsync(new Project { Name = "Other", UrlSlug = "other" });
+            foreach (var project in new[] { "Alpha", "Other" })
+            {
+                await keys.AddAsync(new ApiKey { Name = project, Project = project, KeyHash = project, Fingerprint = project });
+                await links.AddAsync(new ParameterShareLink
+                {
+                    Project = project,
+                    Environment = "production",
+                    Key = "flag",
+                    Token = project,
+                    TokenHash = project,
+                    CreatedBy = "admin@example.com",
+                    CanEdit = true,
+                    ExpiresAt = DateTime.UtcNow.AddDays(1)
+                });
+            }
+            await Assert.That(await keys.GetByKeyHashAsync("Alpha")).IsNotNull();
+            await Assert.That(await links.GetByTokenHashAsync("Alpha")).IsNotNull();
+            await projects.DeleteAsync("ALPHA");
+            await projects.AddAsync(new Project { Name = "alpha", UrlSlug = "alpha" });
+            await Assert.That(await keys.GetByKeyHashAsync("Alpha")).IsNull();
+            await Assert.That(await links.GetByTokenHashAsync("Alpha")).IsNull();
+            await Assert.That(await keys.GetByKeyHashAsync("Other")).IsNotNull();
+            await Assert.That(await links.GetByTokenHashAsync("Other")).IsNotNull();
+            await keys.AddAsync(new ApiKey { Name = "fresh", Project = "alpha", KeyHash = "fresh", Fingerprint = "fresh" });
+            await links.AddAsync(new ParameterShareLink
+            {
+                Project = "alpha",
+                Environment = "production",
+                Key = "flag",
+                Token = "fresh",
+                TokenHash = "fresh",
+                CreatedBy = "admin@example.com",
+                CanEdit = true,
+                ExpiresAt = DateTime.UtcNow.AddDays(1)
+            });
+            await Assert.That(await keys.GetByKeyHashAsync("fresh")).IsNotNull();
+            await Assert.That(await links.GetByTokenHashAsync("fresh")).IsNotNull();
+        }
+        finally
+        {
+            Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+            File.Delete(path);
+        }
+    }
+}

--- a/core/tests/Infrastructure.Tests/SecurityBoundaryRegressionTests.cs
+++ b/core/tests/Infrastructure.Tests/SecurityBoundaryRegressionTests.cs
@@ -1,0 +1,256 @@
+using Nona.Application.Api.ConfigEntries.Queries;
+using Nona.Application.Common.Interfaces;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Nona.Domain.Entities;
+using Nona.Domain.Enums;
+using Nona.Domain.Interfaces;
+using Nona.Infrastructure.Configuration;
+using Nona.Infrastructure.Repositories.Libsql;
+using Nona.Infrastructure.Services;
+using Nona.Infrastructure.Tests.Common;
+using Nona.Libsql;
+
+namespace Nona.Infrastructure.Tests;
+
+public class SecurityBoundaryRegressionTests
+{
+    [Test]
+    [Arguments("InMemory")]
+    [Arguments("Sqlite")]
+    [Arguments("Libsql")]
+    public async Task DeletedResourceCapabilitiesCannotReachReplacement(string storage)
+    {
+        await using var fixture = await StorageFixture.Create(storage);
+        var services = fixture.Services;
+        var projects = services.GetRequiredService<IProjectRepository>();
+        var environments = services.GetRequiredService<IEnvironmentRepository>();
+        var entries = services.GetRequiredService<IConfigEntryRepository>();
+        var keys = services.GetRequiredService<IApiKeyRepository>();
+        var links = services.GetRequiredService<IParameterShareLinkRepository>();
+        await projects.AddAsync(new Project { Name = "Alpha" });
+        await environments.AddAsync(new ProjectEnvironment { Project = "Alpha", Name = "Production" });
+        await environments.AddAsync(new ProjectEnvironment { Project = "Alpha", Name = "Other" });
+        var original = Entry("old");
+        await entries.AddAsync(original);
+        var oldLink = Link("old");
+        await links.AddAsync(oldLink);
+        await keys.AddAsync(new ApiKey { Name = "scoped", Project = "Alpha", Environment = "Production", KeyHash = "scoped", Fingerprint = "scoped" });
+        await keys.AddAsync(new ApiKey { Name = "other", Project = "Alpha", Environment = "Other", KeyHash = "other", Fingerprint = "other" });
+        await keys.AddAsync(new ApiKey { Name = "global", Project = "Alpha", KeyHash = "global", Fingerprint = "global" });
+
+        // A legitimate link reads, writes and records history without changing metadata.
+        await Assert.That((await entries.GetSharedAsync(oldLink, DateTime.UtcNow))!.Value).IsEqualTo("old");
+        var update = Entry("edited");
+        update.Scope = KeyScope.Frontend;
+        update.Description = "stale metadata";
+        var edited = await entries.UpdateSharedValueAsync(update, oldLink, DateTime.UtcNow);
+        await Assert.That(edited!.Scope).IsEqualTo(KeyScope.Backend);
+        await Assert.That(edited.Description).IsEqualTo("keep");
+        await Assert.That((await entries.ListVersionsAsync("Alpha", "Production", "flag")).Count).IsEqualTo(2);
+
+        // Both single and bulk deletion must clear capabilities, case-insensitively.
+        await entries.DeleteAsync("ALPHA", "PRODUCTION", "FLAG");
+        await entries.AddAsync(Entry("replacement"));
+        await Assert.That(await links.GetByTokenHashAsync("old")).IsNull();
+        await Assert.That(await entries.GetSharedAsync(oldLink, DateTime.UtcNow)).IsNull();
+        await Assert.That(await entries.UpdateSharedValueAsync(Entry("attack"), oldLink, DateTime.UtcNow)).IsNull();
+        await Assert.That((await entries.GetAsync("Alpha", "Production", "flag"))!.Value).IsEqualTo("replacement");
+        await Assert.That(await keys.GetByKeyHashAsync("scoped")).IsNotNull();
+        var bulkLink = Link("bulk");
+        await links.AddAsync(bulkLink);
+        await entries.DeleteManyAsync("alpha", "production", ["FLAG"]);
+        await Assert.That(await links.GetByTokenHashAsync("bulk")).IsNull();
+
+        // Remove orphan links too, even when the parameter no longer exists.
+        await links.AddAsync(Link("orphan"));
+        await environments.DeleteAsync("ALPHA", "PRODUCTION");
+        await environments.AddAsync(new ProjectEnvironment { Project = "Alpha", Name = "Production" });
+        await entries.AddAsync(Entry("new environment"));
+        await Assert.That(await keys.GetByKeyHashAsync("scoped")).IsNull();
+        await Assert.That(await links.GetByTokenHashAsync("orphan")).IsNull();
+        await Assert.That(await keys.GetByKeyHashAsync("other")).IsNotNull();
+        await Assert.That(await keys.GetByKeyHashAsync("global")).IsNotNull();
+        var fresh = Link("fresh");
+        await links.AddAsync(fresh);
+        await Assert.That((await entries.GetSharedAsync(fresh, DateTime.UtcNow))!.Value).IsEqualTo("new environment");
+        await Assert.That(await entries.UpdateSharedValueAsync(Entry("fresh edit"), fresh, DateTime.UtcNow)).IsNotNull();
+        await links.RevokeAsync(fresh.Id, DateTime.UtcNow);
+        await Assert.That(await entries.UpdateSharedValueAsync(Entry("revoked"), fresh, DateTime.UtcNow)).IsNull();
+        await Assert.That(await entries.GetSharedAsync(fresh, DateTime.UtcNow)).IsNull();
+        var viewOnly = Link("view");
+        viewOnly.CanEdit = false;
+        await links.AddAsync(viewOnly);
+        await Assert.That(await entries.GetSharedAsync(viewOnly, DateTime.UtcNow)).IsNotNull();
+        await Assert.That(await entries.UpdateSharedValueAsync(Entry("forbidden"), viewOnly, DateTime.UtcNow)).IsNull();
+    }
+
+    [Test]
+    [Arguments("InMemory")]
+    [Arguments("Sqlite")]
+    [Arguments("Libsql")]
+    public async Task BootstrapHasExactlyOneWinnerAcrossConcurrentClients(string storage)
+    {
+        await using var fixture = await StorageFixture.Create(storage);
+        var users = fixture.Services.GetRequiredService<IUserRepository>();
+        using var secondSqliteClient = storage == "Sqlite" ? new SqliteDatabaseClient(fixture.Path) : null;
+        using var secondLibsqlClient = fixture.Sqld?.CreateClient();
+        IUserRepository second = secondSqliteClient is not null ? new LibsqlUserRepository(secondSqliteClient)
+            : secondLibsqlClient is not null ? new LibsqlUserRepository(secondLibsqlClient) : users;
+        using var start = new ManualResetEventSlim();
+        var attempts = Enumerable.Range(0, 8).Select(i => Task.Run(async () =>
+        {
+            start.Wait();
+            return await (i % 2 == 0 ? users : second).TryAddFirstUserAsync(new User
+            {
+                Email = $"admin{i}@example.com",
+                Name = "Admin",
+                Role = UserRole.Admin
+            });
+        })).ToArray();
+        start.Set();
+        var results = await Task.WhenAll(attempts);
+        await Assert.That(results.Count(success => success)).IsEqualTo(1);
+        await Assert.That(await users.CountAsync()).IsEqualTo(1);
+        await Assert.That(await users.TryAddFirstUserAsync(new User { Email = "late@example.com", Name = "Late" })).IsFalse();
+        await users.AddAsync(new User { Email = "member@example.com", Name = "Member" });
+        await Assert.That(await users.CountAsync()).IsEqualTo(2);
+    }
+
+    [Test]
+    [Arguments("InMemory", "value")]
+    [Arguments("InMemory", "all")]
+    [Arguments("InMemory", "release")]
+    [Arguments("InMemory", "release-all")]
+    [Arguments("InMemory", "release-304")]
+    [Arguments("Sqlite", "value")]
+    [Arguments("Sqlite", "all")]
+    [Arguments("Sqlite", "release")]
+    [Arguments("Sqlite", "release-all")]
+    [Arguments("Sqlite", "release-304")]
+    [Arguments("Libsql", "value")]
+    [Arguments("Libsql", "all")]
+    [Arguments("Libsql", "release")]
+    [Arguments("Libsql", "release-all")]
+    [Arguments("Libsql", "release-304")]
+    public async Task InFlightKeyReadRejectsRecreatedEnvironment(string storage, string kind)
+    {
+        await using var fixture = await StorageFixture.Create(storage);
+        var services = fixture.Services;
+        var projects = services.GetRequiredService<IProjectRepository>();
+        var environments = services.GetRequiredService<IEnvironmentRepository>();
+        var entries = services.GetRequiredService<IConfigEntryRepository>();
+        var releases = services.GetRequiredService<IConfigReleaseRepository>();
+        var keys = services.GetRequiredService<IApiKeyRepository>();
+        await projects.AddAsync(new Project { Name = "Alpha" });
+        async Task Seed(string value)
+        {
+            await environments.AddAsync(new ProjectEnvironment { Project = "Alpha", Name = "Production", ActiveReleaseVersion = "1.0.0" });
+            var entry = Entry(value);
+            entry.Scope = KeyScope.All;
+            await entries.AddAsync(entry);
+            await releases.AddAsync(new ConfigRelease
+            {
+                Project = "Alpha",
+                Environment = "Production",
+                Version = "1.0.0",
+                Major = 1,
+                Entries = [new ConfigReleaseEntry { Project = "Alpha", Environment = "Production", ReleaseVersion = "1.0.0", Key = "flag", Value = value, Scope = KeyScope.All }]
+            });
+        }
+        await Seed("old");
+        await keys.AddAsync(new ApiKey { Name = "key", Project = "Alpha", Environment = "Production", KeyHash = "hash", Fingerprint = "hash", Scope = KeyScope.All });
+        async Task<string?> Read(IApiKeyRepository repository)
+        {
+            var keyService = new FixedKeyService();
+            return kind switch
+            {
+                "value" => (await new GetConfigEntryValueQueryHandler(repository, environments, entries, keyService).Handle(new("Production", "flag"), default)).ErrorCode,
+                "all" => (await new GetAllConfigValuesQueryHandler(repository, environments, entries, keyService).Handle(new("Production"), default)).ErrorCode,
+                "release" => (await new GetReleaseConfigEntryValueQueryHandler(repository, environments, releases, keyService).Handle(new("Production", "flag"), default)).ErrorCode,
+                _ => (await new GetAllReleaseConfigValuesQueryHandler(repository, environments, releases, keyService).Handle(new("Production", IfNoneMatch: kind == "release-304" ? "*" : null), default)).ErrorCode
+            };
+        }
+        await Assert.That(await Read(keys)).IsNull();
+        var gatedKeys = new PausedKeyRepository(keys, async () =>
+        {
+            await entries.DeleteAsync("Alpha", "Production", "flag");
+            await releases.DeleteByEnvironmentAsync("Alpha", "Production");
+            await environments.DeleteAsync("Alpha", "Production");
+            await Seed("replacement secret");
+        });
+        await Assert.That(await Read(gatedKeys)).IsEqualTo(RuntimeConfigErrorCodes.InvalidApiKey);
+    }
+
+    private sealed class FixedKeyService : IApiKeyService
+    {
+        public string? GetCurrentApiKeyHash() => "hash";
+    }
+
+    private sealed class PausedKeyRepository(IApiKeyRepository inner, Func<Task> replace) : IApiKeyRepository
+    {
+        private bool _first = true;
+        public async Task<ApiKeyAuthenticationResult?> GetByKeyHashAsync(string hash, CancellationToken ct = default)
+        {
+            var result = await inner.GetByKeyHashAsync(hash, ct);
+            if (_first) { _first = false; await replace(); }
+            return result;
+        }
+        public Task<ApiKey?> GetByIdAsync(long id, CancellationToken ct = default) => inner.GetByIdAsync(id, ct);
+        public Task<IReadOnlyList<ApiKey>> ListByProjectAsync(string project, CancellationToken ct = default) => inner.ListByProjectAsync(project, ct);
+        public Task AddAsync(ApiKey key, CancellationToken ct = default) => inner.AddAsync(key, ct);
+        public Task DeleteAsync(long id, CancellationToken ct = default) => inner.DeleteAsync(id, ct);
+    }
+
+    private static ConfigEntry Entry(string value) => new()
+    {
+        Project = "Alpha",
+        Environment = "Production",
+        Key = "flag",
+        Value = value,
+        Scope = KeyScope.Backend,
+        ContentType = "text",
+        Description = "keep"
+    };
+
+    private static ParameterShareLink Link(string token) => new()
+    {
+        Project = "Alpha",
+        Environment = "Production",
+        Key = "flag",
+        Token = token,
+        TokenHash = token,
+        CreatedBy = "admin",
+        CanEdit = true,
+        ExpiresAt = DateTime.UtcNow.AddHours(1)
+    };
+
+    private sealed class StorageFixture : IAsyncDisposable
+    {
+        public required ServiceProvider Services { get; init; }
+        public required string Path { get; init; }
+        public LocalSqldTestServer? Sqld { get; init; }
+        public static async Task<StorageFixture> Create(string storage)
+        {
+            var path = System.IO.Path.Combine(System.IO.Path.GetTempPath(), $"nona-boundary-{Guid.NewGuid():N}.db");
+            var sqld = storage == "Libsql" ? await LocalSqldTestServer.StartAsync() : null;
+            var configuration = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Storage:Type"] = storage,
+                ["Storage:Sqlite:DataSource"] = path,
+                ["Storage:Libsql:DataSource"] = sqld?.Url,
+                ["Storage:Libsql:ManagedPrimary:Enabled"] = "false"
+            }).Build();
+            var services = new ServiceCollection().AddStorageProvider(configuration).BuildServiceProvider();
+            if (storage != "InMemory") await new LibsqlDatabaseInitializer(services.GetRequiredService<ILibsqlDatabaseClient>()).StartAsync(default);
+            return new StorageFixture { Services = services, Path = path, Sqld = sqld };
+        }
+        public async ValueTask DisposeAsync()
+        {
+            await Services.DisposeAsync();
+            if (Sqld is not null) await Sqld.DisposeAsync();
+            Microsoft.Data.Sqlite.SqliteConnection.ClearAllPools();
+            File.Delete(Path);
+        }
+    }
+}

--- a/deploy/compose/primary-replica-dev.yml
+++ b/deploy/compose/primary-replica-dev.yml
@@ -6,8 +6,6 @@ services:
       dockerfile: Dockerfile
     ports:
       - "${NONA_PRIMARY_API_PORT:-18081}:8080"
-      - "${NONA_PRIMARY_LIBSQL_PORT:-19080}:9080"
-      - "${NONA_PRIMARY_GRPC_PORT:-15001}:5001"
     environment:
       Storage__Libsql__ManagedPrimary__ExtraArgs__0: --grpc-listen-addr
       Storage__Libsql__ManagedPrimary__ExtraArgs__1: 0.0.0.0:5001
@@ -32,7 +30,6 @@ services:
       - nona-primary
     ports:
       - "${NONA_REPLICA_API_PORT:-18082}:8080"
-      - "${NONA_REPLICA_LIBSQL_PORT:-19082}:9080"
     environment:
       Storage__Libsql__ManagedPrimary__ExtraArgs__0: --primary-grpc-url
       Storage__Libsql__ManagedPrimary__ExtraArgs__1: http://nona-primary:5001

--- a/deploy/compose/primary-replica-prod.yml
+++ b/deploy/compose/primary-replica-prod.yml
@@ -4,8 +4,6 @@ services:
     restart: unless-stopped
     ports:
       - "${NONA_PRIMARY_API_PORT:-18081}:8080"
-      - "${NONA_PRIMARY_LIBSQL_PORT:-19080}:9080"
-      - "${NONA_PRIMARY_GRPC_PORT:-15001}:5001"
     environment:
       Storage__Libsql__ManagedPrimary__ExtraArgs__0: --grpc-listen-addr
       Storage__Libsql__ManagedPrimary__ExtraArgs__1: 0.0.0.0:5001
@@ -31,7 +29,6 @@ services:
       - nona-primary
     ports:
       - "${NONA_REPLICA_API_PORT:-18082}:8080"
-      - "${NONA_REPLICA_LIBSQL_PORT:-19082}:9080"
     environment:
       Storage__Libsql__ManagedPrimary__ExtraArgs__0: --primary-grpc-url
       Storage__Libsql__ManagedPrimary__ExtraArgs__1: http://nona-primary:5001

--- a/docs/src/content/docs/deployment/primary-replica.md
+++ b/docs/src/content/docs/deployment/primary-replica.md
@@ -33,8 +33,10 @@ Do not choose it just because it sounds more production-like. For many teams, st
 
 | Service | API | libSQL HTTP | Replication gRPC |
 |---|---:|---:|---:|
-| `nona-primary` | `18081 -> 8080` | `19080 -> 9080` | `15001 -> 5001` |
-| `nona-replica` | `18082 -> 8080` | `19082 -> 9080` | not exposed |
+| `nona-primary` | `18081 -> 8080` | internal only | internal only |
+| `nona-replica` | `18082 -> 8080` | internal only | not exposed |
+
+The replication compose files publish only the Nona API. SQL HTTP and replication gRPC stay on the private container network; Nona authentication does not protect these database listeners.
 
 Use the primary API for admin and write workflows. Use the replica API for read-heavy clients when eventual consistency is acceptable.
 
@@ -47,10 +49,7 @@ Set these environment variables before `docker compose up`:
 | Variable | Default | Meaning |
 |---|---:|---|
 | `NONA_PRIMARY_API_PORT` | `18081` | Host port for the primary Nona API |
-| `NONA_PRIMARY_LIBSQL_PORT` | `19080` | Host port for the primary libSQL HTTP service |
-| `NONA_PRIMARY_GRPC_PORT` | `15001` | Host port for primary replication gRPC |
 | `NONA_REPLICA_API_PORT` | `18082` | Host port for the replica Nona API |
-| `NONA_REPLICA_LIBSQL_PORT` | `19082` | Host port for the replica libSQL HTTP service |
 
 Example:
 

--- a/docs/src/content/docs/operations/security-and-authentication.md
+++ b/docs/src/content/docs/operations/security-and-authentication.md
@@ -152,3 +152,17 @@ Share links are useful for narrow temporary collaboration, but they are not a re
 - [Users and project access](/docs/concepts/users-and-project-access)
 - [Parameter share links](/docs/parameter-share-links)
 - [Deployment](/docs/deployment)
+
+### Session and project credential revocation
+
+Changing or resetting a password invalidates all previously issued sessions, including the current session. Sign in again using the new password. JWTs issued before credential binding was introduced are also rejected after upgrading.
+
+Deleting a project removes its API keys and parameter share links. Recreating a project with the same name requires new credentials.
+
+### Resource deletion and CLI authorization
+
+Deleting an environment revokes its environment-scoped API keys and all parameter share links. Deleting an individual parameter revokes its share links, including during bulk deletion. Recreating the same names does not restore these capabilities; issue new credentials for the replacement resources. Project-wide API keys retain their project-wide scope.
+
+CLI browser login requires an explicit **Authorize CLI** confirmation showing the account and local callback destination, including after signing in. Approve it only when you initiated login from your terminal. The CLI callback protocol is unchanged.
+
+Session transitions clear cached administration data and reject responses started under the previous session. Initial administrator registration atomically allows only one successful bootstrap request.

--- a/tools/tests/test_security_boundaries.py
+++ b/tools/tests/test_security_boundaries.py
@@ -1,0 +1,70 @@
+"""Regression checks for deployment exposure and the developer hook's temp files."""
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class SecurityBoundaries(unittest.TestCase):
+    def test_replication_publishes_only_nona_api(self):
+        for mode in ("dev", "prod"):
+            text = (ROOT / f"deploy/compose/primary-replica-{mode}.yml").read_text()
+            # Inspect every host port mapping, independently of its chosen host port.
+            mappings = re.findall(r'^\s+- "\$\{[^}]+\}:(\d+)"\s*$', text, re.M)
+            self.assertEqual(mappings, ["8080", "8080"])
+            self.assertIn("http://nona-primary:5001", text)
+            self.assertIn("http://nona-primary:9080", text)
+
+    def test_hook_does_not_follow_precreated_symlinks(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            tools = root / "bin"
+            tools.mkdir()
+            hook = root / "pre-push"
+            shutil.copyfile(ROOT / ".githooks/pre-push", hook)
+            hook.chmod(0o700)
+            git = tools / "git"
+            git.write_text('#!/bin/sh\ncase "$*" in *--show-toplevel*) printf "%s\\n" "$TEST_ROOT";; esac\n')
+            git.chmod(0o700)
+            target = root / "victim.txt"
+            target.write_text("must survive")
+            temp = root / "shared temp"
+            temp.mkdir()
+            env = dict(os.environ, PATH=f"{tools}:{os.environ['PATH']}", TEST_ROOT=str(root),
+                       TMPDIR=str(temp), TEST_HOOK=str(hook), TEST_TARGET=str(target))
+            script = '''
+                directory="$TMPDIR/nona-pre-push.$$"
+                mkdir "$directory"
+                ln -s "$TEST_TARGET" "$directory/refs"
+                ln -s "$TEST_TARGET" "$directory/cs-files"
+                ln -s "$TEST_TARGET" "$directory/dotnet-files"
+                exec "$TEST_HOOK" </dev/null
+            '''
+            result = subprocess.run(["sh", "-c", script], env=env, capture_output=True, text=True)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("No pushed .NET files", result.stdout)
+            self.assertEqual(target.read_text(), "must survive")
+            # Only the adversarial directory remains; the hook removes its own allocation.
+            self.assertEqual(len(list(temp.iterdir())), 1)
+
+    def test_hook_fails_when_temp_allocation_fails(self):
+        with tempfile.TemporaryDirectory() as directory:
+            tools = Path(directory)
+            for name, body in [("git", 'printf "%s\\n" "$TMPDIR"'), ("mktemp", "exit 1")]:
+                executable = tools / name
+                executable.write_text(f"#!/bin/sh\n{body}\n")
+                executable.chmod(0o700)
+            result = subprocess.run(["sh", str(ROOT / ".githooks/pre-push")],
+                                    env=dict(os.environ, TMPDIR=directory, PATH=f"{tools}:{os.environ['PATH']}"),
+                                    capture_output=True)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertEqual(sorted(p.name for p in tools.iterdir()), ["git", "mktemp"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Deleted and recreated resources could remain accessible through previously issued credentials, and password changes did not invalidate existing sessions. This change enforces credential lifecycle boundaries and addresses the six findings from the repository security review.

- Revoke affected API keys and share links on resource deletion, protect issuance and in-flight reads/writes against resource replacement, and invalidate JWTs after password changes or resets.
- Keep sqld ports private in both Compose deployments and require explicit consent before returning a session token to the CLI.
- Clear cached admin data on session changes, reject stale responses, and handle logout or account changes across tabs.
- Make first-user registration atomic and allocate private temporary directories in the pre-push hook.
- Add regression coverage and update deployment and authentication documentation.

Validation: 778 tests passed (271 Application, 179 Infrastructure including real libSQL, 325 admin, 3 Python). Solution build, TypeScript, ESLint, C# formatting, shell syntax and whitespace checks passed.

Deployment: deploy the updated application and recreate Compose containers to remove existing published database ports. No database migration or API contract change is required. Existing JWTs without the credential stamp will require users to sign in again. Credentials associated with resources recreated before this upgrade may require manual revocation. Compose port configuration was checked structurally; a full Docker deployment was not run.
